### PR TITLE
Adds the service mapper and reducer configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const config = require('../../config');
+
 const checkers = [
   require('../services/checkers/code-review'),
   require('../services/checkers/qa-review'),
@@ -13,6 +15,6 @@ const releaseService = require('../services/releaseService')(github);
 
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
-  getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo),
+  getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo, config),
   createRelease: require('./createRelease')(github, boundIssueExtractor, releaseService)
 };


### PR DESCRIPTION
In order to allow each organization to modify the services output We've introduced a configuration file where a mapper and/or reducer can be defined and they are applied on the `services` data before sending the output.

See https://github.com/AudienseCo/monorail/blob/4bcd32af8487e63445cd0f9672dfc0aca90d2a58/test/core/actions/getPullRequestsDeployInfo_spec.js