### PR TITLE
Adds the new labels-checker to warn when there isnt any deploy label assigned in the PR

### DIFF
--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -5,7 +5,8 @@ const config = require('../../config');
 const checkers = [
   require('../services/checkers/code-review'),
   require('../services/checkers/qa-review'),
-  require('../services/checkers/deploy-notes')
+  require('../services/checkers/deploy-notes'),
+  require('../services/checkers/deploy-labels')
 ];
 
 const github = require('../../lib/github');

--- a/core/services/checkers/deploy-labels/deployLabelsChecker.js
+++ b/core/services/checkers/deploy-labels/deployLabelsChecker.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = function(github) {
+  const that = {};
+
+  that.checkPullRequest = (prInfo, cb) => {
+    github.getIssueLabels(prInfo.number, (err, labels) => {
+      if (err) return cb(err);
+
+      const hasdDeployLabels = labels.some(label => label.name.toLowerCase().match(/^deploy-to:/));
+
+      if (!hasdDeployLabels) {
+        cb(null, {
+          state: 'failure',
+          context: 'Deploy Labels'
+        });
+      }
+      else cb(null, {
+        state: 'success',
+        context: 'Deploy Labels'
+      });
+    });
+  };
+
+  return that;
+};

--- a/core/services/checkers/deploy-labels/deployLabelsService.js
+++ b/core/services/checkers/deploy-labels/deployLabelsService.js
@@ -1,0 +1,28 @@
+'use strict';
+const async = require('async');
+
+module.exports = function createDeployNotesService(deployLabelsChecker, github) {
+  const that = {};
+
+  that.updatePullRequestCommit = (prInfo) => {
+    async.waterfall([
+      function check(next) {
+        deployLabelsChecker.checkPullRequest(prInfo, next);
+      },
+      function getPR(status, next) {
+        github.getPullRequest(prInfo.number, (err, pr) => {
+          next(err, status, pr);
+        });
+      },
+      function update(status, pr, next) {
+        status.sha = pr.head.sha;
+        github.updateCommitStatus(status, (err, result) => {
+          if (err) console.log('Update commit state error', err);
+          else console.log('Updated commit state');
+        });
+      }
+    ]);
+  };
+
+  return that;
+};

--- a/core/services/checkers/deploy-labels/deployLabelsSubscriber.js
+++ b/core/services/checkers/deploy-labels/deployLabelsSubscriber.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = function(emitter, deployLabelsService) {
+  const that = {
+    subscribe: () => {
+      emitter.on('pull_request', payload => {
+        if (payload.action === 'opened' || payload.action === 'labeled' ||
+        payload.action === 'unlabeled') {
+          const prInfo = payload.pull_request;
+          deployLabelsService.updatePullRequestCommit(prInfo);
+        }
+      });
+
+      emitter.on('issue_comment', payload => {
+        if (payload.action === 'created' && payload.issue && payload.issue.pull_request) {
+          if (payload.comment.body.toLowerCase() === 'check deploy labels please') {
+            const prInfo = payload.issue;
+            deployLabelsService.updatePullRequestCommit(prInfo);
+          }
+        }
+      });
+    }
+  };
+  return that;
+};

--- a/core/services/checkers/deploy-labels/index.js
+++ b/core/services/checkers/deploy-labels/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const github = require('../../../../lib/github');
+const createDeployLabelsSubscriber = require('./deployLabelsSubscriber');
+const createDeployLabelsService    = require('./deployLabelsService');
+const createDeployLabelsChecker    = require('./deployLabelsChecker');
+
+module.exports = {
+  subscribe: (emitter) => {
+    const deployLabelsChecker  = createDeployLabelsChecker(github);
+    const deployLabelsService  = createDeployLabelsService(deployLabelsChecker, github);
+    const deployLabelsSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+    deployLabelsSubscriber.subscribe();
+  }
+};

--- a/test/core/services/checkers/deploy-labels/builder_spec.js
+++ b/test/core/services/checkers/deploy-labels/builder_spec.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const deployNotes = require('../../../../../core/services/checkers/deploy-labels');
+
+describe('Deploy labels module builder', () => {
+
+  context('Interface', () => {
+    it('should have the "subscribe" method', () => {
+      deployNotes.subscribe.should.be.a.Function();
+    });
+  });
+
+});

--- a/test/core/services/checkers/deploy-labels/deployNotesChecker_spec.js
+++ b/test/core/services/checkers/deploy-labels/deployNotesChecker_spec.js
@@ -1,0 +1,47 @@
+'use strict';
+
+require('should');
+
+const createDeployLablesChecker = require('../../../../../core/services/checkers/deploy-labels/deployLabelsChecker');
+
+describe('Deploy notes checker', () => {
+
+  function createGithubDummy(result) {
+    return {
+      getIssueLabels: (issue, cb) => {
+        cb(null, result);
+      }
+    };
+  }
+  context('Interface', () => {
+    const deployLabels = createDeployLablesChecker();
+    it('should have the "check" method', () => {
+      deployLabels.checkPullRequest.should.be.a.Function();
+    });
+  });
+
+  context('Behaviour', () => {
+
+    it('should return an error status if there are not any deploy label', done => {
+      const githubDummy = createGithubDummy([{ name: 'other label' }]);
+
+      const deployLabels = createDeployLablesChecker(githubDummy);
+      deployLabels.checkPullRequest({ body: '#1234' }, (err, status) => {
+        status.context.should.be.eql('Deploy Labels');
+        status.state.should.be.eql('failure');
+        done();
+      });
+    });
+
+    it('should return a success status if there is any deploy label', done => {
+      const githubDummy = createGithubDummy([{ name: 'deploy-to:tasks' }]);
+
+      const deployLabels = createDeployLablesChecker(githubDummy);
+      deployLabels.checkPullRequest({ body: '#1234' }, (err, status) => {
+        status.context.should.be.eql('Deploy Labels');
+        status.state.should.be.eql('success');
+        done();
+      });
+    });
+  });
+});

--- a/test/core/services/checkers/deploy-labels/deployNotesService_spec.js
+++ b/test/core/services/checkers/deploy-labels/deployNotesService_spec.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('should');
+const createDeployLabelsService = require(`../../../../../\
+core/services/checkers/deploy-labels/deployLabelsService`);
+
+describe('Deploy labels service', () => {
+  const deployLabelsService = createDeployLabelsService();
+
+  context('Interface', () => {
+    it('should have the "updatePullRequestCommit" method', () => {
+      deployLabelsService.updatePullRequestCommit.should.be.a.Function();
+    });
+  });
+});

--- a/test/core/services/checkers/deploy-labels/deployNotesSubscriber_spec.js
+++ b/test/core/services/checkers/deploy-labels/deployNotesSubscriber_spec.js
@@ -1,0 +1,180 @@
+'use strict';
+
+require('should');
+const sinon = require('sinon');
+const EventEmitter = require('events');
+const createDeployLabelsSubscriber = require('../../../../../core/services/checkers/deploy-labels/deployLabelsSubscriber');
+const createDeployLabelsService = require('../../../../../core/services/checkers/deploy-labels/deployLabelsService');
+
+describe('Deploy labels subscriber', () => {
+  function createDeployLabelsCheckerDummy(result) {
+    return {
+      checkPullRequest: (prInfo, cb) => {
+        cb(null, result);
+      }
+    };
+  }
+
+  function createGithubDummy(result) {
+    return {
+      getPullRequest: (issue, cb) => {
+        cb(null, result);
+      },
+      updateCommitStatus: (status, cb) => {
+        cb(null, result);
+      }
+    };
+  }
+
+  context('Interface', () => {
+    const deployLablesSubscriber = createDeployLabelsSubscriber();
+    it('should have the "subscribe" method', () => {
+      deployLablesSubscriber.subscribe.should.be.a.Function();
+    });
+  });
+
+  context('Behaviour', () => {
+    it('should subscribe to the "pull_request" event', done => {
+      const emitter = new EventEmitter();
+      const spy = sinon.spy(emitter, 'on');
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter);
+      deployLablesSubscriber.subscribe();
+      spy.calledWith('pull_request').should.be.ok();
+      done();
+    });
+
+    it('should subscribe to the "issue_comment" event', done => {
+      const emitter = new EventEmitter();
+      const spy = sinon.spy(emitter, 'on');
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter);
+      deployLablesSubscriber.subscribe();
+      spy.calledWith('issue_comment').should.be.ok();
+      done();
+    });
+
+    it('should call the deploy label checker on new pull requests', done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({ head: { sha: '' } });
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'opened',
+        number: 1234,
+        pull_request: {}
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('pull_request', payload);
+      spy.calledOnce.should.be.ok();
+      done();
+    });
+
+    it('should not call the deploy labels service on close a pull request', done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({ head: { sha: '' } });
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'closed',
+        number: 1234,
+        pull_request: {}
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('pull_request', payload);
+      spy.calledOnce.should.not.be.ok();
+      done();
+    });
+
+    it(`should call the deploy labels service when a user comment "check
+    deploy labels please"`, done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({ head: { sha: '' } });
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'created',
+        issue: {
+          pull_request: {}
+        },
+        comment: {
+          body: 'check deploy labels please'
+        }
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('issue_comment', payload);
+      spy.calledOnce.should.be.ok();
+      done();
+    });
+
+    it(`should call the deploy labels service when a user comment "check deploy
+    labels please" (case insensitive)`, done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({ head: { sha: '' } });
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'created',
+        issue: {
+          pull_request: {}
+        },
+        comment: {
+          body: 'Check deploy labels please'
+        }
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('issue_comment', payload);
+      spy.calledOnce.should.be.ok();
+      done();
+    });
+
+    it('should not call the deploy labels service when a user write any comment on the PR', done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({});
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'created',
+        issue: {
+          pull_request: {}
+        },
+        comment: {
+          body: 'Dummy text comment'
+        }
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('issue_comment', payload);
+      spy.calledOnce.should.not.be.ok();
+      done();
+    });
+
+    it('should not call the deploy labels service for a comment on an issue', done => {
+      const emitter = new EventEmitter();
+      const deployLabelsCheckerDummy = createDeployLabelsCheckerDummy({});
+      const githubDummy = createGithubDummy({});
+      const deployLabelsService = createDeployLabelsService(deployLabelsCheckerDummy, githubDummy);
+      const deployLablesSubscriber = createDeployLabelsSubscriber(emitter, deployLabelsService);
+      const spy = sinon.spy(deployLabelsService, 'updatePullRequestCommit');
+      const payload = {
+        action: 'created',
+        issue: {
+        },
+        comment: {
+          body: 'check deploy labels please'
+        }
+      };
+      deployLablesSubscriber.subscribe();
+      emitter.emit('issue_comment', payload);
+      spy.calledOnce.should.not.be.ok();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
It's expected that every PR has deploy labels assigned, otherwise there would be a warning in github