### PR TITLE
Issue participants

### DIFF
--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -18,7 +18,9 @@ module.exports = function(github, boundIssueExtractor, releaseService) {
       });
     }, (err, issues) => {
       if (err) cb(err);
-      else releaseService.create(tag, issues, cb);
+      else releaseService.create(tag, issues, (releaseError) => {
+        cb(releaseError, issues);
+      });
     });
   };
 };

--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -2,38 +2,17 @@
 
 const async = require('async');
 
-module.exports = function(github, boundIssueExtractor, releaseService, issueParticipants) {
+module.exports = function(issueReleaseInfo, releaseService) {
   return function(tag, ids, cb) {
-    async.reduce(ids, [], (acc, id, next) => {
-      async.waterfall([
-        function getPRInfo(next) {
-          github.getPullRequest(id, next);
-        },
 
-        function getBoundIssue(prInfo, next) {
-          const boundIssue = boundIssueExtractor.extract(prInfo.body);
-          if (!boundIssue) return next(null, [prInfo]);
-
-          github.getIssue(boundIssue, (err, issueInfo) => {
-            next(err, [prInfo, issueInfo]);
-          });
-        },
-
-        function getParticipants(issueList, next) {
-          issueParticipants.getParticipants(issueList, (err, participants) => {
-            next(err, issueList, participants);
-          });
-        },
-
-        function pickIssue(issueList, participants, next) {
-          next(null, issueList[1] || issueList[0], participants);
-        }
-      ], (err, issue, participants) => {
-        next(err, acc.concat({ issue: issue, participants: participants }));
+    async.map(ids, (id, next) => {
+      issueReleaseInfo.getInfo(id, (err, issueReleaseInfo) => {
+        next(err, issueReleaseInfo);
       });
     }, (err, releaseInfo) => {
       if (err) cb(err);
       else releaseService.create(tag, releaseInfo, cb);
     });
+
   };
 };

--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -33,9 +33,7 @@ module.exports = function(github, boundIssueExtractor, releaseService, issuePart
       });
     }, (err, releaseInfo) => {
       if (err) cb(err);
-      else releaseService.create(tag, releaseInfo, (releaseError) => {
-        cb(releaseError, releaseInfo);
-      });
+      else releaseService.create(tag, releaseInfo, cb);
     });
   };
 };

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -13,7 +13,7 @@ const github = require('../../lib/github');
 const pullRequestDeployInfo = require('../services/pullRequestDeployInfo')(github);
 const boundIssueExtractor = require('../services/boundIssueExtractor')();
 const releaseService = require('../services/releaseService')(github);
-const issueParticipants = require('../services/issueParticipants')(github);
+const issueParticipants = require('../services/issueParticipants')(github, config);
 const issueReleaseInfo = require('../services/issueReleaseInfo')(github,
   boundIssueExtractor, issueParticipants);
 

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -14,11 +14,12 @@ const pullRequestDeployInfo = require('../services/pullRequestDeployInfo')(githu
 const boundIssueExtractor = require('../services/boundIssueExtractor')();
 const releaseService = require('../services/releaseService')(github);
 const issueParticipants = require('../services/issueParticipants')(github);
+const issueReleaseInfo = require('../services/issueReleaseInfo')(github,
+  boundIssueExtractor, issueParticipants);
 
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
   getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo, config),
-  createRelease: require('./createRelease')(github, boundIssueExtractor,
-    releaseService, issueParticipants),
+  createRelease: require('./createRelease')(issueReleaseInfo, releaseService),
   previewRelease: require('./previewRelease')(github, boundIssueExtractor)
 };

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -13,10 +13,12 @@ const github = require('../../lib/github');
 const pullRequestDeployInfo = require('../services/pullRequestDeployInfo')(github);
 const boundIssueExtractor = require('../services/boundIssueExtractor')();
 const releaseService = require('../services/releaseService')(github);
+const issueParticipants = require('../services/issueParticipants')(github);
 
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
   getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo, config),
-  createRelease: require('./createRelease')(github, boundIssueExtractor, releaseService),
+  createRelease: require('./createRelease')(github, boundIssueExtractor,
+    releaseService, issueParticipants),
   previewRelease: require('./previewRelease')(github, boundIssueExtractor)
 };

--- a/core/services/issueParticipants.js
+++ b/core/services/issueParticipants.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const async = require('async');
+
+module.exports = function(github) {
+  const that = {};
+
+  that.getParticipants = (issueItem, cb) => {
+    github.getIssueComments(issueItem.number, (err, comments) => {
+      if (err) return cb(err);
+
+      const initial = new Set([issueItem.user.login]);
+      async.reduce(comments, initial, (participants, comment, done) => {
+        const author = comment.user.login;
+        done(null, participants.add(author));
+      }, onFinish);
+    });
+
+    function onFinish(err, participants) {
+      cb(err, participants ? Array.from(participants) : []);
+    }
+  };
+
+  return that;
+};

--- a/core/services/issueParticipants.js
+++ b/core/services/issueParticipants.js
@@ -2,7 +2,7 @@
 
 const async = require('async');
 
-module.exports = function(github) {
+module.exports = function(github, config) {
   const that = {};
 
   that.getParticipants = (listOrIssue, cb) => {
@@ -15,7 +15,7 @@ module.exports = function(github) {
     }, onFinish);
 
     function onFinish(err, participants) {
-      cb(err, participants ? Array.from(new Set(participants)) : []);
+      cb(err, participants ? map(Array.from(new Set(participants))) : []);
     }
   };
 
@@ -29,6 +29,11 @@ module.exports = function(github) {
         done(null, participants.concat(author));
       }, cb);
     });
+  }
+
+  function map(participants) {
+    if (!config || !config.users || !config.users.map) return participants;
+    return participants.map(config.users.map);
   }
 
   return that;

--- a/core/services/issueReleaseInfo.js
+++ b/core/services/issueReleaseInfo.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var async = require('async');
+
+module.exports = function(github, boundIssueExtractor, issueParticipants) {
+  const that = {};
+
+  that.getInfo = function(prId, cb) {
+    async.waterfall([
+
+      function getPRInfo(next) {
+        github.getPullRequest(prId, next);
+      },
+
+      function getBoundIssue(prInfo, next) {
+        const boundIssue = boundIssueExtractor.extract(prInfo.body);
+        if (!boundIssue) return next(null, [prInfo]);
+
+        github.getIssue(boundIssue, (err, issueInfo) => {
+          next(err, [prInfo, issueInfo]);
+        });
+      },
+
+      function getParticipants(issueList, next) {
+        issueParticipants.getParticipants(issueList, (err, participants) => {
+          next(err, issueList, participants);
+        });
+      },
+
+      function pickIssue(issueList, participants, next) {
+        next(null, issueList[1] || issueList[0], participants);
+      },
+
+      function format(issue, participants, next) {
+        next(null, { issue: issue, participants: participants });
+      }
+    ], cb);
+  };
+
+  return that;
+};

--- a/core/services/releaseService.js
+++ b/core/services/releaseService.js
@@ -10,7 +10,9 @@ module.exports = function(github) {
           return compose(info);
         }).join('\n')
       };
-      github.createRelease(data, cb);
+      github.createRelease(data, err => {
+        cb(err, data);
+      });
     }
   };
 };

--- a/core/services/releaseService.js
+++ b/core/services/releaseService.js
@@ -10,6 +10,7 @@ module.exports = function(github) {
           return compose(info);
         }).join('\n')
       };
+
       github.createRelease(data, err => {
         cb(err, data);
       });

--- a/core/services/releaseService.js
+++ b/core/services/releaseService.js
@@ -2,13 +2,23 @@
 
 module.exports = function(github) {
   return {
-    create: (tag, issues, cb) => {
-      const releaseInfo = {
+    create: (tag, releaseInfo, cb) => {
+      const data = {
         tag_name: tag,
         name: tag + ' Release',
-        body: issues.map(issue => { return '#' + issue.number + ' ' + issue.title; }).join('\n')
+        body: releaseInfo.map(info => {
+          return compose(info);
+        }).join('\n')
       };
-      github.createRelease(releaseInfo, cb);
+      github.createRelease(data, cb);
     }
   };
 };
+
+function compose(releaseIssueInfo) {
+  const issue = releaseIssueInfo.issue;
+  const participants = releaseIssueInfo.participants.join(', ');
+
+  return '#' + issue.number + ' ' + issue.title +
+    (participants.length ? '. cc ' + participants : '');
+}

--- a/lib/github/github.js
+++ b/lib/github/github.js
@@ -29,6 +29,12 @@ module.exports = function(githubApi, config) {
     githubApi.issues.getRepoIssue(msg, cb);
   };
 
+  that.getIssueComments = (issue, cb) => {
+    const info = { number: issue, per_page: 100 };
+    const msg = Object.assign({}, buildMsg(info));
+    githubApi.issues.getComments(msg, cb);
+  };
+
   that.createRelease = (info, cb) => {
     const msg = Object.assign({}, buildMsg(info), { owner: config.user });
     githubApi.releases.createRelease(msg, cb);

--- a/test/core/actions/createRelease_spec.js
+++ b/test/core/actions/createRelease_spec.js
@@ -44,9 +44,16 @@ describe('Create release action', () => {
       boundIssueExtractor = createBoundIssueExtractor();
     });
 
+    const issueParticipantsDummy = {
+      getParticipants: (issues, cb) => {
+        cb(null, []);
+      }
+    };
+
     it('should fetch the PR info', done => {
       const releaseService = createReleaseService(githubDummy);
-      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'getPullRequest');
@@ -60,7 +67,8 @@ describe('Create release action', () => {
 
     it('should extract the bound issues', done => {
       const releaseService = createReleaseService(githubDummy);
-      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(boundIssueExtractor, 'extract');
@@ -74,7 +82,8 @@ describe('Create release action', () => {
 
     it('should fetch the bound issues info', done => {
       const releaseService = createReleaseService(githubDummy);
-      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'getIssue');
@@ -88,7 +97,8 @@ describe('Create release action', () => {
 
     it('should create the release with the issues info', done => {
       const releaseService = createReleaseService(githubDummy);
-      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'createRelease');
@@ -104,13 +114,38 @@ describe('Create release action', () => {
       });
     });
 
+    it('should include the participants', done => {
+      const issueParticipantsDummy = {
+        getParticipants: (issues, cb) => {
+          cb(null, ['ana', 'joe']);
+        }
+      };
+      const releaseService = createReleaseService(githubDummy);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
+      const tag = 'v1.2.3';
+      const ids = [1];
+      const spy = sinon.spy(githubDummy, 'createRelease');
+
+      createRelease(tag, ids, err => {
+        should.not.exist(err);
+        spy.calledWith({
+          tag_name: 'v1.2.3',
+          name: 'v1.2.3 Release',
+          body: '#1234 Bar issue. cc ana, joe'
+        }).should.be.ok();
+        done();
+      });
+    });
+
     it('should use the PR title if there is not issue bound', done => {
       sinon.stub(githubDummy, 'getPullRequest').callsArgWith(1, null, {
         title: 'Foo pr', number: '4321'
       });
       sinon.stub(boundIssueExtractor, 'extract').onFirstCall().returns(null);
       const releaseService = createReleaseService(githubDummy);
-      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+      const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+        issueParticipantsDummy);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'createRelease');
@@ -133,7 +168,8 @@ describe('Create release action', () => {
           cb('foo_error');
         });
         const releaseService = createReleaseService(githubDummy);
-        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+          issueParticipantsDummy);
         const tag = 'v1.2.3';
         const ids = [1];
 
@@ -148,7 +184,8 @@ describe('Create release action', () => {
           cb('foo_error');
         });
         const releaseService = createReleaseService(githubDummy);
-        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+          issueParticipantsDummy);
         const tag = 'v1.2.3';
         const ids = [1];
 
@@ -163,7 +200,8 @@ describe('Create release action', () => {
           cb('foo_error');
         });
         const releaseService = createReleaseService(githubDummy);
-        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService);
+        const createRelease = createCreateRelease(githubDummy, boundIssueExtractor, releaseService,
+          issueParticipantsDummy);
         const tag = 'v1.2.3';
         const ids = [1];
 

--- a/test/core/services/issueParticipants_spec.js
+++ b/test/core/services/issueParticipants_spec.js
@@ -62,6 +62,38 @@ describe('issueParticipants service', () => {
       });
     });
 
+    it('should get the list of people mapped using the config', done => {
+      const config = {
+        users: {
+          map: user => {
+            return '@' + user;
+          }
+        }
+      };
+      const issueItem = {
+        number: 1234,
+        user: {
+          login: 'foo'
+        }
+      };
+      const comments = [
+        {
+          id: 2,
+          user: {
+            login: 'bar'
+          }
+        }
+      ];
+
+      const githubDummy = createGithubDummy(comments);
+      const issueParticipants = createIssueParticipants(githubDummy, config);
+
+      issueParticipants.getParticipants(issueItem, (err, participants) => {
+        participants.should.be.eql(['@foo', '@bar']);
+        done();
+      });
+    });
+
     it('should get the list of people who commented the PR (avoid duplicates)', done => {
       const comments = [
         {

--- a/test/core/services/issueParticipants_spec.js
+++ b/test/core/services/issueParticipants_spec.js
@@ -1,0 +1,103 @@
+'use strict';
+
+require('should');
+
+const createIssueParticipants = require('../../../core/services/issueParticipants');
+
+describe('issueParticipants service', () => {
+
+  context('Interface', () => {
+    const issueParticipants = createIssueParticipants();
+    it('should have the "getParticipants" method', () => {
+      issueParticipants.getParticipants.should.be.a.Function();
+    });
+  });
+
+  context('Behaviour', () => {
+
+    function createGithubDummy(result) {
+      return {
+        getIssueComments: (issue, cb) => {
+          cb(null, result);
+        }
+      };
+    }
+
+    it('should get the issue author name as least', done => {
+      const comments = [];
+      const githubDummy = createGithubDummy(comments);
+      const issueParticipants = createIssueParticipants(githubDummy);
+      const issueItem = {
+        number: 1234,
+        user: {
+          login: 'foo'
+        }
+      };
+      issueParticipants.getParticipants(issueItem, (err, participants) => {
+        participants.should.be.eql(['foo']);
+        done();
+      });
+    });
+
+    it('should get the list of people who commented the PR', done => {
+      const comments = [
+        {
+          id: 2,
+          user: {
+            login: 'bar'
+          }
+        }
+      ];
+      const githubDummy = createGithubDummy(comments);
+      const issueParticipants = createIssueParticipants(githubDummy);
+      const issueItem = {
+        number: 1234,
+        user: {
+          login: 'foo'
+        }
+      };
+      issueParticipants.getParticipants(issueItem, (err, participants) => {
+        participants.should.be.eql(['foo', 'bar']);
+        done();
+      });
+    });
+
+    it('should get the list of people who commented the PR (avoid duplicates)', done => {
+      const comments = [
+        {
+          id: 1,
+          user: {
+            login: 'foo'
+          }
+        },
+        {
+          id: 2,
+          user: {
+            login: 'bar'
+          }
+        },
+        {
+          id: 3,
+          user: {
+            login: 'bar'
+          }
+        }
+      ];
+      const githubDummy = createGithubDummy(comments);
+      const issueParticipants = createIssueParticipants(githubDummy);
+      const issueItem = {
+        number: 1234,
+        user: {
+          login: 'foo'
+        }
+      };
+
+      issueParticipants.getParticipants(issueItem, (err, participants) => {
+        participants.length.should.be.eql(2);
+        participants.should.be.eql(['foo', 'bar']);
+        done();
+      });
+    });
+
+  });
+});

--- a/test/core/services/issueParticipants_spec.js
+++ b/test/core/services/issueParticipants_spec.js
@@ -99,5 +99,44 @@ describe('issueParticipants service', () => {
       });
     });
 
+    it('should get the participants for a list of issues', done => {
+      const comments = [
+        {
+          id: 1,
+          user: {
+            login: 'john'
+          }
+        },
+        {
+          id: 2,
+          user: {
+            login: 'ana'
+          }
+        }
+      ];
+      const githubDummy = createGithubDummy(comments);
+      const issueParticipants = createIssueParticipants(githubDummy);
+      const issues = [
+        {
+          number: 1234,
+          user: {
+            login: 'foo'
+          }
+        },
+        {
+          number: 4321,
+          user: {
+            login: 'bar'
+          }
+        }
+      ];
+
+      issueParticipants.getParticipants(issues, (err, participants) => {
+        participants.length.should.be.eql(4);
+        participants.should.be.eql(['foo', 'john', 'ana', 'bar']);
+        done();
+      });
+    });
+
   });
 });

--- a/test/core/services/releaseService_spec.js
+++ b/test/core/services/releaseService_spec.js
@@ -28,21 +28,27 @@ describe('Create release service', () => {
       const spy = sinon.spy(githubDummy, 'createRelease');
       const releaseService = createReleaseService(githubDummy);
       const tag = 'v1.3.0';
-      const issues = [
+      const info = [
         {
-          number: 1234,
-          title: 'Foo issue'
+          issue: {
+            number: 1234,
+            title: 'Foo issue'
+          },
+          participants: []
         },
         {
-          number: 4321,
-          title: 'Bar issue'
+          issue: {
+            number: 4321,
+            title: 'Bar issue'
+          },
+          participants: ['ana']
         }
       ];
-      releaseService.create(tag, issues, (err, result) => {
+      releaseService.create(tag, info, (err, result) => {
         spy.calledWith({
           tag_name: 'v1.3.0',
           name: 'v1.3.0 Release',
-          body: '#1234 Foo issue\n#4321 Bar issue'
+          body: '#1234 Foo issue\n#4321 Bar issue. cc ana'
         }).should.be.ok();
         done();
       });

--- a/test/lib/github/github_spec.js
+++ b/test/lib/github/github_spec.js
@@ -27,6 +27,10 @@ describe('Github API wrapper', () => {
     it('should have the "createRelease" method', () => {
       github.createRelease.should.be.a.Function();
     });
+
+    it('should have the "getIssueComments" method', () => {
+      github.getIssueComments.should.be.a.Function();
+    });
   });
 
   context('Behaviour', () => {
@@ -39,6 +43,9 @@ describe('Github API wrapper', () => {
             cb(null, result);
           },
           getRepoIssue: (number, cb) => {
+            cb(null, result);
+          },
+          getComments: (number, cb) => {
             cb(null, result);
           }
         },
@@ -132,6 +139,22 @@ describe('Github API wrapper', () => {
           user: 'AudienseCo',
           repo: 'socialbro',
           number: 1234
+        }).should.be.ok();
+        done();
+      });
+    });
+
+    it('should get the comments for an issue', done => {
+      const githubApiDummy = createGithubDummy([{ id: 1234 }]);
+      const github = createGithub(githubApiDummy, config);
+      const spy = sinon.spy(githubApiDummy.issues, 'getComments');
+      github.getIssueComments(1234, (err, result) => {
+        result.length.should.be.eql(1);
+        spy.calledWith({
+          user: 'AudienseCo',
+          repo: 'socialbro',
+          number: 1234,
+          per_page: 100
         }).should.be.ok();
         done();
       });


### PR DESCRIPTION
Include the participant names for each issue in the release notes.

The participants are extracted combining the issue author name with all the people who commented on it.

It's posible to map the user names using the `users.map` function configuration.