### PR TITLE
Apply checkers when new commits are pushed to a PR

### DIFF
--- a/core/services/checkers/deploy-labels/deployLabelsSubscriber.js
+++ b/core/services/checkers/deploy-labels/deployLabelsSubscriber.js
@@ -5,7 +5,7 @@ module.exports = function(emitter, deployLabelsService) {
     subscribe: () => {
       emitter.on('pull_request', payload => {
         if (payload.action === 'opened' || payload.action === 'labeled' ||
-        payload.action === 'unlabeled') {
+        payload.action === 'unlabeled' || payload.action === 'synchronize') {
           const prInfo = payload.pull_request;
           deployLabelsService.updatePullRequestCommit(prInfo);
         }

--- a/core/services/checkers/deploy-notes/deployNotesSubscriber.js
+++ b/core/services/checkers/deploy-notes/deployNotesSubscriber.js
@@ -5,7 +5,7 @@ module.exports = function(emitter, deployNotesService) {
     subscribe: () => {
       emitter.on('pull_request', payload => {
         if (payload.action === 'opened' || payload.action === 'labeled' ||
-        payload.action === 'unlabeled') {
+        payload.action === 'unlabeled' || payload.action === 'synchronize') {
           const prInfo = payload.pull_request;
           deployNotesService.updatePullRequestCommit(prInfo);
         }

--- a/core/services/checkers/qa-review/qaReviewSubscriber.js
+++ b/core/services/checkers/qa-review/qaReviewSubscriber.js
@@ -5,7 +5,7 @@ module.exports = function(emitter, qaReviewService) {
     subscribe: () => {
       emitter.on('pull_request', payload => {
         if (payload.action === 'opened' || payload.action === 'labeled' ||
-        payload.action === 'unlabeled') {
+        payload.action === 'unlabeled' || payload.action === 'synchronize') {
           const prInfo = payload.pull_request;
           qaReviewService.updatePullRequestCommit(prInfo);
         }


### PR DESCRIPTION
Fixes #13 
The `synchronize` event was missing.