### PR TITLE
Filtered release notes

### DIFF
--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -26,7 +26,9 @@ module.exports = function(issueReleaseInfoList, releaseInfoLabel, releaseNotesFo
       },
 
       (body, next) => {
-        releaseService.create(tag, body, next);
+        releaseService.create(tag, body, error => {
+          next(error, body);
+        });
       }
 
     ], cb);

--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -2,27 +2,31 @@
 
 const async = require('async');
 
-module.exports = function(issueReleaseInfo, releaseInfoLabel, releaseService) {
+module.exports = function(issueReleaseInfoList, releaseInfoLabel, releaseNotesFormatter,
+  releaseService) {
+
   return function(tag, ids, cb) {
 
     async.waterfall([
-      function getIssues(next) {
-        async.map(ids, (id, nextId) => {
-          issueReleaseInfo.getInfo(id, (err, issueReleaseInfo) => {
-            nextId(err, issueReleaseInfo);
-          });
-        }, next);
+
+      (next) => {
+        issueReleaseInfoList.get(ids, next);
       },
 
-      function setIssuesAsDeployed(releaseInfo, next) {
-        releaseInfoLabel.addLabels(releaseInfo, ['deployed'], err => {
-          if (err) { console.log('Error adding the deployed label:', err); }
-          next(null, releaseInfo);
+      (releaseInfoList, next) => {
+        releaseInfoLabel.addLabels(releaseInfoList, ['deployed'], err => {
+          if (err) { console.error('Error adding the deployed label:', err); }
+          next(null, releaseInfoList);
         });
       },
 
-      function createRelease(releaseInfo, next) {
-        releaseService.create(tag, releaseInfo, next);
+      (releaseInfoList, next) => {
+        var body = releaseNotesFormatter.format(releaseInfoList);
+        next(null, body);
+      },
+
+      (body, next) => {
+        releaseService.create(tag, body, next);
       }
 
     ], cb);

--- a/core/actions/createRelease.js
+++ b/core/actions/createRelease.js
@@ -21,7 +21,7 @@ module.exports = function(issueReleaseInfoList, releaseInfoLabel, releaseNotesFo
       },
 
       (releaseInfoList, next) => {
-        var body = releaseNotesFormatter.format(releaseInfoList);
+        const body = releaseNotesFormatter.format(releaseInfoList);
         next(null, body);
       },
 

--- a/core/actions/getReleaseNotes.js
+++ b/core/actions/getReleaseNotes.js
@@ -10,7 +10,6 @@ module.exports = function getReleaseNotesBuilder(issueReleaseInfoList, releaseNo
       },
 
       (releaseInfoList, next) => {
-        console.log('Filter', filterLabels);
         if (!filterLabels || filterLabels.length === 0) return next(null, releaseInfoList);
 
         const filteredReleaseInfoList = releaseInfoList.filter(info => {

--- a/core/actions/getReleaseNotes.js
+++ b/core/actions/getReleaseNotes.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const async = require('async');
+
+module.exports = function getReleaseNotesBuilder(issueReleaseInfoList, releaseNotesFormatter) {
+  return (ids, filterLabels, callback) => {
+    async.waterfall([
+      (next) => {
+        issueReleaseInfoList.get(ids, next);
+      },
+
+      (releaseInfoList, next) => {
+        console.log('Filter', filterLabels);
+        if (!filterLabels || filterLabels.length === 0) return next(null, releaseInfoList);
+
+        const filteredReleaseInfoList = releaseInfoList.filter(info => {
+          if (!info.issue || !info.issue.labels) return false;
+
+          var labels = info.issue.labels.map(labelInfo => labelInfo.name);
+          return labels.indexOf(filterLabels[0]) > -1;
+        });
+
+        next(null, filteredReleaseInfoList);
+      },
+
+      (releaseInfoList, next) => {
+        var body = releaseNotesFormatter.format(releaseInfoList);
+        next(null, body);
+      }
+    ], callback);
+  };
+};

--- a/core/actions/getReleaseNotes.js
+++ b/core/actions/getReleaseNotes.js
@@ -15,7 +15,7 @@ module.exports = function getReleaseNotesBuilder(issueReleaseInfoList, releaseNo
         const filteredReleaseInfoList = releaseInfoList.filter(info => {
           if (!info.issue || !info.issue.labels) return false;
 
-          var labels = info.issue.labels.map(labelInfo => labelInfo.name);
+          const labels = info.issue.labels.map(labelInfo => labelInfo.name);
           return labels.indexOf(filterLabels[0]) > -1;
         });
 
@@ -23,7 +23,7 @@ module.exports = function getReleaseNotesBuilder(issueReleaseInfoList, releaseNo
       },
 
       (releaseInfoList, next) => {
-        var body = releaseNotesFormatter.format(releaseInfoList);
+        const body = releaseNotesFormatter.format(releaseInfoList);
         next(null, body);
       }
     ], callback);

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -22,7 +22,8 @@ const releaseNotesFormatter = require('../services/releaseNotesFormatter')();
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
   getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo, config),
-  createRelease: require('./createRelease')(issueReleaseInfo, releaseInfoLabel, releaseService),
+  createRelease: require('./createRelease')(issueReleaseInfoList, releaseInfoLabel,
+    releaseNotesFormatter, releaseService),
   previewRelease: require('./previewRelease')(github, boundIssueExtractor),
   getReleaseNotes: require('./getReleaseNotes')(issueReleaseInfoList, releaseNotesFormatter)
 };

--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -16,10 +16,13 @@ const issueParticipants = require('../services/issueParticipants')(github, confi
 const issueReleaseInfo = require('../services/issueReleaseInfo')(github,
   boundIssueExtractor, issueParticipants);
 const releaseInfoLabel = require('../services/releaseInfoLabel')(github);
+const issueReleaseInfoList = require('../services/issueReleaseInfoList')(issueReleaseInfo);
+const releaseNotesFormatter = require('../services/releaseNotesFormatter')();
 
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
   getPullRequestsDeployInfo: require('./getPullRequestsDeployInfo')(pullRequestDeployInfo, config),
   createRelease: require('./createRelease')(issueReleaseInfo, releaseInfoLabel, releaseService),
-  previewRelease: require('./previewRelease')(github, boundIssueExtractor)
+  previewRelease: require('./previewRelease')(github, boundIssueExtractor),
+  getReleaseNotes: require('./getReleaseNotes')(issueReleaseInfoList, releaseNotesFormatter)
 };

--- a/core/services/issueReleaseInfo.js
+++ b/core/services/issueReleaseInfo.js
@@ -9,7 +9,7 @@ module.exports = function(github, boundIssueExtractor, issueParticipants) {
     async.waterfall([
 
       function getPRInfo(next) {
-        github.getPullRequest(prId, next);
+        github.getIssue(prId, next);
       },
 
       function getBoundIssue(prInfo, next) {

--- a/core/services/issueReleaseInfoList.js
+++ b/core/services/issueReleaseInfoList.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const async = require('async');
+
+module.exports = function issueReleaseInfoListBuilder(issueReleaseInfo) {
+  const that = {};
+
+  that.get = (ids, callback) => {
+    async.map(ids, (id, nextId) => {
+      issueReleaseInfo.getInfo(id, (err, issueReleaseInfo) => {
+        nextId(err, issueReleaseInfo);
+      });
+    }, callback);
+  };
+
+  return that;
+};

--- a/core/services/releaseNotesFormatter.js
+++ b/core/services/releaseNotesFormatter.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function releaseNotesFormatter() {
+
+  function compose(releaseIssueInfo) {
+    const issue = releaseIssueInfo.issue;
+    const participants = releaseIssueInfo.participants.join(', ');
+
+    return '#' + issue.number + ' ' + issue.title +
+      (participants.length ? '. cc ' + participants : '');
+  }
+
+  return {
+    format: (releaseInfoList) => {
+      return releaseInfoList.map(compose).join('\n');
+    }
+  };
+};

--- a/core/services/releaseService.js
+++ b/core/services/releaseService.js
@@ -2,13 +2,11 @@
 
 module.exports = function(github) {
   return {
-    create: (tag, releaseInfo, cb) => {
+    create: (tag, body, cb) => {
       const data = {
         tag_name: tag,
         name: tag + ' Release',
-        body: releaseInfo.map(info => {
-          return compose(info);
-        }).join('\n')
+        body: body
       };
 
       github.createRelease(data, err => {
@@ -17,11 +15,3 @@ module.exports = function(github) {
     }
   };
 };
-
-function compose(releaseIssueInfo) {
-  const issue = releaseIssueInfo.issue;
-  const participants = releaseIssueInfo.participants.join(', ');
-
-  return '#' + issue.number + ' ' + issue.title +
-    (participants.length ? '. cc ' + participants : '');
-}

--- a/test/core/actions/createRelease_spec.js
+++ b/test/core/actions/createRelease_spec.js
@@ -7,6 +7,8 @@ const createCreateRelease = require('../../../core/actions/createRelease');
 const createReleaseService = require('../../../core/services/releaseService');
 const createBoundIssueExtractor = require('../../../core/services/boundIssueExtractor');
 const createIssueReleaseInfo = require('../../../core/services/issueReleaseInfo');
+const createReleaseNotesFormatter = require('../../../core/services/releaseNotesFormatter');
+const createIssueReleaseInfoList = require('../../../core/services/issueReleaseInfoList');
 
 describe('Create release action', () => {
 
@@ -69,7 +71,10 @@ describe('Create release action', () => {
       const releaseService = createReleaseService(githubDummy);
       const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
         issueParticipantsDummy);
-      const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel, releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
 
@@ -85,7 +90,10 @@ describe('Create release action', () => {
       const releaseService = createReleaseService(githubDummy);
       const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
         issueParticipantsDummy);
-      const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel, releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(boundIssueExtractor, 'extract');
@@ -102,7 +110,10 @@ describe('Create release action', () => {
       const releaseService = createReleaseService(githubDummy);
       const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
         issueParticipantsDummy);
-      const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel, releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
 
@@ -118,7 +129,10 @@ describe('Create release action', () => {
       const releaseService = createReleaseService(githubDummy);
       const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
         issueParticipantsDummy);
-      const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel, releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(releaseInfoLabel, 'addLabels');
@@ -137,8 +151,10 @@ describe('Create release action', () => {
         issue: { number: 1234, title: 'Bar issue' },
         participants: []
       });
-      const createRelease = createCreateRelease(issueReleaseInfoDummy, releaseInfoLabel,
-        releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfoDummy);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'createRelease');
@@ -161,8 +177,10 @@ describe('Create release action', () => {
         issue: { number: 1234, title: 'Bar issue' },
         participants: ['ana', 'joe']
       });
-      const createRelease = createCreateRelease(issueReleaseInfoDummy, releaseInfoLabel,
-        releaseService);
+      const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfoDummy);
+      const releaseNotesFormatter = createReleaseNotesFormatter();
+      const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+        releaseNotesFormatter, releaseService);
       const tag = 'v1.2.3';
       const ids = [1];
       const spy = sinon.spy(githubDummy, 'createRelease');
@@ -186,8 +204,10 @@ describe('Create release action', () => {
         const releaseService = createReleaseService(githubDummy);
         const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
           issueParticipantsDummy);
-        const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel,
-          releaseService);
+        const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+        const releaseNotesFormatter = createReleaseNotesFormatter();
+        const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+          releaseNotesFormatter, releaseService);
         const tag = 'v1.2.3';
         const ids = [1];
 
@@ -203,9 +223,10 @@ describe('Create release action', () => {
         const releaseService = createReleaseService(githubDummy);
         const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
           issueParticipantsDummy);
-        const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel,
-          releaseService,
-          issueParticipantsDummy);
+        const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+        const releaseNotesFormatter = createReleaseNotesFormatter();
+        const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+          releaseNotesFormatter, releaseService);
         const tag = 'v1.2.3';
         const ids = [1];
 
@@ -223,8 +244,10 @@ describe('Create release action', () => {
         const releaseService = createReleaseService(githubDummy);
         const issueReleaseInfo = createIssueReleaseInfo(githubDummy, boundIssueExtractor,
           issueParticipantsDummy);
-        const createRelease = createCreateRelease(issueReleaseInfo, releaseInfoLabel,
-          releaseService);
+        const issueReleaseInfoList = createIssueReleaseInfoList(issueReleaseInfo);
+        const releaseNotesFormatter = createReleaseNotesFormatter();
+        const createRelease = createCreateRelease(issueReleaseInfoList, releaseInfoLabel,
+          releaseNotesFormatter, releaseService);
         const tag = 'v1.2.3';
         const ids = [1];
 

--- a/test/core/actions/createRelease_spec.js
+++ b/test/core/actions/createRelease_spec.js
@@ -22,7 +22,7 @@ describe('Create release action', () => {
   context('Behaviour', () => {
 
     function createGithubDummy(prInfo, issueInfo) {
-      var that = {
+      const that = {
         getPullRequest: (id, cb) => {
           cb(null, prInfo);
         },

--- a/test/core/actions/index_spec.js
+++ b/test/core/actions/index_spec.js
@@ -22,5 +22,9 @@ describe('Actions builder', () => {
       actions.previewRelease.should.be.a.Function();
     });
 
+    it('should have the "getReleaseNotes method"', () => {
+      actions.getReleaseNotes.should.be.a.Function();
+    });
+
   });
 });

--- a/test/core/actions/releaseNotes_spec.js
+++ b/test/core/actions/releaseNotes_spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+require('should');
+
+const getReleaseNotesBuilder = require('../../../core/actions/getReleaseNotes');
+const releaseNotesFormatterBuilder = require('../../../core/services/releaseNotesFormatter');
+
+describe('Get release notes', () => {
+
+  it('should return all the releaase notes', done => {
+    const ids = ['1234', '4321'];
+    const filterLabels = [];
+    const expected = '#1234 Bar issue\n#4321 Foo issue';
+
+    const issueReleaseInfoListFake = _createIssueReleaseInfoListFake();
+    const releaseNotesFormatter = releaseNotesFormatterBuilder();
+    const getReleaseNotes = getReleaseNotesBuilder(issueReleaseInfoListFake, releaseNotesFormatter);
+    getReleaseNotes(ids, filterLabels, (error, notes) => {
+      notes.should.be.eql(expected);
+      done();
+    });
+  });
+
+  it('should return just the releaase notes filtered by label', done => {
+    const ids = ['1234', '4321'];
+    const filterLabels = ['notify:staff'];
+    const expected = '#1234 Bar issue';
+
+    const issueReleaseInfoListFake = _createIssueReleaseInfoListFake();
+    const releaseNotesFormatter = releaseNotesFormatterBuilder();
+    const getReleaseNotes = getReleaseNotesBuilder(issueReleaseInfoListFake, releaseNotesFormatter);
+    getReleaseNotes(ids, filterLabels, (error, notes) => {
+      notes.should.be.eql(expected);
+      done();
+    });
+  });
+
+  it('should return empty if there is not any match', done => {
+    const ids = ['1234', '4321'];
+    const filterLabels = ['notify:unexisting'];
+    const expected = '';
+
+    const issueReleaseInfoListFake = _createIssueReleaseInfoListFake();
+    const releaseNotesFormatter = releaseNotesFormatterBuilder();
+    const getReleaseNotes = getReleaseNotesBuilder(issueReleaseInfoListFake, releaseNotesFormatter);
+    getReleaseNotes(ids, filterLabels, (error, notes) => {
+      notes.should.be.eql(expected);
+      done();
+    });
+  });
+
+  function _createIssueReleaseInfoListFake() {
+    return {
+      get: (ids, next) => {
+        const releaseInfo = [
+          {
+            issue: {
+              number: '1234',
+              title: 'Bar issue',
+              labels: [
+                {
+                  name: 'notify:staff'
+                }
+              ]
+            },
+            participants: []
+          },
+          {
+            issue: { number: '4321', title: 'Foo issue', labels: [] },
+            participants: []
+          }
+        ];
+        next(null, releaseInfo);
+      }
+    };
+  }
+});
+

--- a/test/core/services/issueReleaseInfoList_spec.js
+++ b/test/core/services/issueReleaseInfoList_spec.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const issueReleaseInfoListBuilder = require('../../../core/services/issueReleaseInfoList');
+
+describe('issueReleaseInfoList service', () => {
+
+  it('should get the issue release info for a list of ids', done => {
+    const ids = [1, 2, 3];
+    const expected = [
+      { issue: { number: 1 } },
+      { issue: { number: 2 } },
+      { issue: { number: 3 } }
+    ];
+
+    const issueReleaseInfoFake = _createIssueReleaseInfoFake();
+    const issueReleaseInfoList = issueReleaseInfoListBuilder(issueReleaseInfoFake);
+    issueReleaseInfoList.get(ids, (error, list) => {
+      list.should.be.eql(expected);
+      done();
+    });
+  });
+
+  function _createIssueReleaseInfoFake() {
+    return {
+      getInfo: (id, callback) => callback(null, { issue: { number: id } })
+    };
+  }
+});

--- a/test/core/services/issueReleaseInfo_spec.js
+++ b/test/core/services/issueReleaseInfo_spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('should');
+var sinon = require('sinon');
 
 const createIssueReleaseInfo = require('../../../core/services/issueReleaseInfo');
 const createBoundIssueExtractor = require('../../../core/services/boundIssueExtractor');
@@ -16,14 +17,15 @@ function createIssueParticipantsDummy(result) {
 }
 
 function createGithubDummy(pr, issue) {
-  return {
-    getPullRequest: (number, cb) => {
-      cb(null, pr);
-    },
+  var that = {
     getIssue: (number, cb) => {
       cb(null, issue);
     }
   };
+  sinon.stub(that, 'getIssue')
+        .onCall(0).callsArgWith(1, null, pr)
+        .onCall(1).callsArgWith(1, null, issue);
+  return that;
 }
 
 describe('issueReleaseInfo service', () => {

--- a/test/core/services/issueReleaseInfo_spec.js
+++ b/test/core/services/issueReleaseInfo_spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('should');
-var sinon = require('sinon');
+const sinon = require('sinon');
 
 const createIssueReleaseInfo = require('../../../core/services/issueReleaseInfo');
 const createBoundIssueExtractor = require('../../../core/services/boundIssueExtractor');
@@ -17,7 +17,7 @@ function createIssueParticipantsDummy(result) {
 }
 
 function createGithubDummy(pr, issue) {
-  var that = {
+  const that = {
     getIssue: (number, cb) => {
       cb(null, issue);
     }

--- a/test/core/services/releaseNotesFormatter_spec.js
+++ b/test/core/services/releaseNotesFormatter_spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const releaseNotesFormatter = require('../../../core/services/releaseNotesFormatter')();
+
+describe('releaseNotesFormatter service', () => {
+
+  it('should create a text with a list of relaseInfo data', () => {
+    const relaseInfoList = [
+      {
+        issue: { number: 1, title: 'Foo issue' },
+        participants: []
+      },
+      {
+        issue: { number: 2, title: 'Bar issue' },
+        participants: []
+      }
+    ];
+    const expected = '#1 Foo issue\n#2 Bar issue';
+
+    releaseNotesFormatter.format(relaseInfoList).should.be.eql(expected);
+  });
+
+  it('should include the participants if there is any', () => {
+    const relaseInfoList = [
+      {
+        issue: { number: 1, title: 'Foo issue' },
+        participants: ['Ana', 'Carlos']
+      },
+      {
+        issue: { number: 2, title: 'Bar issue' },
+        participants: []
+      }
+    ];
+    const expected = '#1 Foo issue. cc Ana, Carlos\n#2 Bar issue';
+
+    releaseNotesFormatter.format(relaseInfoList).should.be.eql(expected);
+  });
+});

--- a/test/core/services/releaseService_spec.js
+++ b/test/core/services/releaseService_spec.js
@@ -28,23 +28,9 @@ describe('Create release service', () => {
       const spy = sinon.spy(githubDummy, 'createRelease');
       const releaseService = createReleaseService(githubDummy);
       const tag = 'v1.3.0';
-      const info = [
-        {
-          issue: {
-            number: 1234,
-            title: 'Foo issue'
-          },
-          participants: []
-        },
-        {
-          issue: {
-            number: 4321,
-            title: 'Bar issue'
-          },
-          participants: ['ana']
-        }
-      ];
-      releaseService.create(tag, info, (err, result) => {
+      const body = '#1234 Foo issue\n#4321 Bar issue. cc ana';
+
+      releaseService.create(tag, body, (err, result) => {
         spy.calledWith({
           tag_name: 'v1.3.0',
           name: 'v1.3.0 Release',

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -56,11 +56,32 @@ module.exports = function(actions) {
     const pullRequestIds    = pullRequestIdsStr.split(',');
 
     actions.previewRelease(pullRequestIds, (err, result) => {
-      if (err) res.status(400).send(err);
+      if (err) return res.status(400).send(err);
 
       const info = result.map(issue => {
         return `#${issue.number} ${issue.title}`;
       });
+
+      res.status(200).send(info);
+    });
+
+  });
+
+  app.get('/release-notes', (req, res) => {
+    if (!req.query.pr)
+      return res.status(400).send({ error: 'You must include the "pr" parameter' });
+
+    const pullRequestIdsStr = req.query.pr;
+    const pullRequestIds    = pullRequestIdsStr.split(',');
+    const filterLabelsStr   = req.query.labels || '';
+    const filterLabels      = filterLabelsStr.length ? filterLabelsStr.split(',') : [];
+
+    actions.getReleaseNotes(pullRequestIds, filterLabels, (err, result) => {
+      if (err) return res.status(400).send(err);
+
+      const info = {
+        body: result
+      };
 
       res.status(200).send(info);
     });

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -42,8 +42,13 @@ module.exports = function(actions) {
     const pullRequestIds    = pullRequestIdsStr.split(',');
 
     actions.createRelease(tagName, pullRequestIds, (err, result) => {
-      if (err) res.status(400).send(err);
-      else res.status(200).send(result);
+      if (err) return res.status(400).send(err);
+
+      const info = {
+        body: result
+      };
+
+      res.status(200).send(info);
     });
 
   });


### PR DESCRIPTION
- A new endpoint `/release-notes` has been added.
- The endpoint `/create-release` has been refactored to make use of extracted services.

## /release-notes
Get the info to display for the specified pull requests ids. The info can be filtered to get just certain labeled pull requests.

### Params

name|required|description
----- | --------|-----------
pr      | true       | Comma separated list of Pull Requests to get the info. Example: `6012,531`
labels| false     | Comma separated list of labels to filter for. Example: `notify-to:staff`

### Example
```
/release-notes?pr=6012,6005&labels=notify-to:staff
```
### Response
```json
{ "body" : "#6012 My issue title. cc @ana" }
```