### PR TITLE
The new job use ',' as separator

### DIFF
--- a/scripts/deploy_services.py
+++ b/scripts/deploy_services.py
@@ -96,7 +96,7 @@ for batch_same_node_version in services:
     services_list = set()
     for service in batch_same_node_version['deploy']:
         services_list.add(service)
-    payload['where_to_deploy'] = list(services_list)
+    payload['where_to_deploy'] = ','.join(services_list)
 
     try:
         r = requests.post(request_jenkins, auth=(args.jenkinsUser, args.jenkinsApiToken), params=payload)


### PR DESCRIPTION
Related with https://github.com/AudienseCo/systeam/issues/2345

To avoid the error:

```
Caused by: java.lang.IllegalArgumentException: Illegal number of parameter values for where_to_deploy: 3
```

The job called before `Generate_tarball_multijob` had a multiple option selector. The new one has a free string field and the '`,`' should be used to pass multiple services.