### PR TITLE
Deploy endpoint returns 202 and continue in background

### DIFF
--- a/web/private/index.js
+++ b/web/private/index.js
@@ -111,12 +111,13 @@ module.exports = function(actions) {
   app.get('/deploy', (req, res) => {
     const showPreview = req.query.showPreview || false;
     const repos = req.query.repos || config.github.repos;
+    res.status(202).send('Acepted');
     actions.startDeploy(repos, showPreview, (err) => {
       if (err) {
         console.error('Error', err);
         return res.status(400).send(err);
       }
-      res.status(200).send('OK');
+      console.info('Deploy finished');
     });
 
   });

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -119,7 +119,7 @@ module.exports = function(actions) {
       console.info('Deploy finished');
     });
 
-    res.status(202).send('Acepted');
+    res.status(202).send('Accepted');
   });
 
 

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -111,15 +111,15 @@ module.exports = function(actions) {
   app.get('/deploy', (req, res) => {
     const showPreview = req.query.showPreview || false;
     const repos = req.query.repos || config.github.repos;
-    res.status(202).send('Acepted');
+    console.info('Deploy started');
     actions.startDeploy(repos, showPreview, (err) => {
       if (err) {
         console.error('Error', err);
-        return res.status(400).send(err);
       }
       console.info('Deploy finished');
     });
 
+    res.status(202).send('Acepted');
   });
 
 


### PR DESCRIPTION
The deploy endpoints could take some minutes depending on the CI driver build job. 
This PR changes its behaviour so that it responds immediately with a 202 Accepted and continues the work in the background. The result should be check in slack. In the future, we should expose other restfull mechanisms to poll the job status.