### PR TITLE
Verbose mode

### DIFF
--- a/core/actions/slackPreviewRelease.js
+++ b/core/actions/slackPreviewRelease.js
@@ -4,11 +4,11 @@ const { waterfall, mapSeries } = require('async');
 
 module.exports = function createPreviewRelease(getConfig, getReleasePreview, notify, repos) {
 
-  return (cb) => {
+  return ({ verbose = false }, cb) => {
     waterfall([
       (next)            => getConfigForEachRepo(repos, next),
       (reposInfo, next) => getReleasePreview(reposInfo, next),
-      (reposInfo, next) => notifyPreviewInSlack(reposInfo, next)
+      (reposInfo, next) => notifyPreviewInSlack(reposInfo, verbose, next)
     ], cb);
   };
 
@@ -24,7 +24,7 @@ module.exports = function createPreviewRelease(getConfig, getReleasePreview, not
     }, cb);
   }
 
-  function notifyPreviewInSlack(reposInfo, cb) {
-    notify(reposInfo, 'preview', cb);
+  function notifyPreviewInSlack(reposInfo, verbose, cb) {
+    notify(reposInfo, 'preview', verbose, cb);
   }
 };

--- a/core/actions/startDeploy.js
+++ b/core/actions/startDeploy.js
@@ -11,12 +11,12 @@ module.exports = (
   cleanUpDeploy,
   notify
 ) => {
-  return (repos, showPreview, cb) => {
+  return ({ repos, showPreview, verbose = false }, cb) => {
     waterfall([
       (next)            => getConfigForEachRepo(repos, next),
       (reposInfo, next) => createTemporaryBranchesForEachRepo(reposInfo, next),
       (reposInfo, next) => getReleasePreview(reposInfo, next),
-      (reposInfo, next) => notifyPreviewSlackIfEnabled(showPreview, reposInfo, next),
+      (reposInfo, next) => notifyPreviewSlackIfEnabled(showPreview, reposInfo, verbose, next),
       (reposInfo, next) => deployEachRepo(reposInfo, next),
       (reposInfo, next) => notifyRelease(reposInfo, next),
     ], (err, reposInfo) => {
@@ -54,9 +54,9 @@ module.exports = (
       }, cb);
     }
 
-    function notifyPreviewSlackIfEnabled(showPreview, reposInfo, cb) {
+    function notifyPreviewSlackIfEnabled(showPreview, reposInfo, verbose, cb) {
       if (!showPreview) return cb(null, reposInfo);
-      notify(reposInfo, 'preview', err => cb(err, reposInfo));
+      notify(reposInfo, 'preview', verbose, err => cb(err, reposInfo));
     }
 
     function deployEachRepo(reposInfo, cb) {
@@ -79,7 +79,7 @@ module.exports = (
     }
 
     function notifyRelease(reposInfo, cb) {
-      notify(reposInfo, 'release', err => cb(err, reposInfo));
+      notify(reposInfo, 'release', verbose, err => cb(err, reposInfo));
     }
 
   };

--- a/core/services/notify.js
+++ b/core/services/notify.js
@@ -4,14 +4,14 @@ const { get } = require('lodash');
 const { eachSeries } = require('async');
 
 module.exports = (templates, slack, config) => {
-  return (reposInfo, notificationName, cb) => {
+  return (reposInfo, notificationName, verbose, cb) => {
     const template = templates[notificationName];
     if (!template) return cb(new Error('No template defined for this notification name'));
     const notificationSettings = get(config, `slack.notifications['${notificationName}']`);
     if (!notificationSettings) return cb(new Error('There are no settings for this notification name'));
 
     eachSeries(notificationSettings, (channelInfo, next) => {
-      const msg = template(reposInfo, channelInfo.labels);
+      const msg = template(reposInfo, channelInfo.labels, verbose);
       if (!msg) return next();
       // TODO: publish verbose errors in another channel
       slack.send(channelInfo.channel, msg, next);

--- a/presentation/slack/release/index.js
+++ b/presentation/slack/release/index.js
@@ -5,13 +5,15 @@ const ERROR_TEMPLATES = require('./errors');
 const releaseMsg = require('./release');
 
 module.exports = (config) => {
-  return (releaseInfo, filterLabels) => {
+  return (releaseInfo, filterLabels, verbose) => {
     const user = get(config, 'github.user');
     const githubToSlakUsernames = get(config, 'slack.githubUsers');
 
     // TODO: add a config setting to notify only if there are filterred issues
     const attachments = releaseInfo.reduce((acc, repoInfo) => {
       if (isFailedReleaseAndFilteredChannel(repoInfo.failReason, filterLabels)) return acc;
+      if (thereIsNoChangesAndInSilentMode(repoInfo.failReason, verbose)) return acc;
+
       const attachment = repoInfo.failReason
         ? ERROR_TEMPLATES[repoInfo.failReason] || ERROR_TEMPLATES.UNkNOWN_ERROR
         : releaseMsg(repoInfo, filterLabels, user, githubToSlakUsernames);
@@ -34,4 +36,9 @@ module.exports = (config) => {
   function isFailedReleaseAndFilteredChannel(failReason, filterLabels) {
     return failReason && filterLabels && filterLabels.length > 0;
   }
+
+  function thereIsNoChangesAndInSilentMode(failReason, verbose) {
+    return failReason === 'NO_CHANGES' && !verbose;
+  }
+
 };

--- a/test/core/actions/slackPreviewRelease_spec.js
+++ b/test/core/actions/slackPreviewRelease_spec.js
@@ -37,8 +37,8 @@ describe('slackPreviewRelease action', () => {
       const githubDummy = createGithubDummy(prInfo, issueInfo, commitsInfo);
       const notifyStub = createNotifyStub();
       const previewRelease = createPrevieReleaseWithStubs({ github: githubDummy, notify: notifyStub });
-
-      previewRelease((err) => {
+      const options = {};
+      previewRelease(options, (err) => {
         should.not.exist(err);
         const reposInfo = notifyStub.firstCall.args[0];
         reposInfo[0].failReason.should.be.eql('NO_CHANGES');
@@ -53,8 +53,8 @@ describe('slackPreviewRelease action', () => {
       stub.onSecondCall().callsArgWith(2, null, [{ name: 'deploy-to:globalreports' }]);
       const notifyStub = createNotifyStub();
       const previewRelease = createPrevieReleaseWithStubs({ github: githubDummy, notify: notifyStub });
-
-      previewRelease((err) => {
+      const options = {};
+      previewRelease(options, (err) => {
         should.not.exist(err);
         const reposInfo = notifyStub.firstCall.args[0];
         reposInfo[0].failReason.should.be.eql('DEPLOY_NOTES');
@@ -69,8 +69,8 @@ describe('slackPreviewRelease action', () => {
       stub.onSecondCall().callsArgWith(2, null, []);
       const notifyStub = createNotifyStub();
       const previewRelease = createPrevieReleaseWithStubs({ github: githubDummy, notify: notifyStub });
-
-      previewRelease((err) => {
+      const options = {};
+      previewRelease(options, (err) => {
         should.not.exist(err);
         const reposInfo = notifyStub.firstCall.args[0];
         reposInfo[0].failReason.should.be.eql('NO_SERVICES');
@@ -85,8 +85,8 @@ describe('slackPreviewRelease action', () => {
       stub.onSecondCall().callsArgWith(2, null, [{ name: 'deploy-to:globalreports' }]);
       const notifyStub = createNotifyStub();
       const previewRelease = createPrevieReleaseWithStubs({ github: githubDummy, notify: notifyStub });
-
-      previewRelease((err) => {
+      const options = {};
+      previewRelease(options, (err) => {
         should.not.exist(err);
         const firstRepo = notifyStub.firstCall.args[0][0];
         firstRepo.repo.should.be.eql('socialbro');
@@ -172,7 +172,7 @@ describe('slackPreviewRelease action', () => {
     }
 
     function createNotifyStub() {
-      const notify = (reposInfo, notificationName, cb) => cb();
+      const notify = (reposInfo, notificationName, verbose, cb) => cb();
       return sinon.spy(notify);
     }
 

--- a/test/core/actions/startDeploy_spec.js
+++ b/test/core/actions/startDeploy_spec.js
@@ -35,7 +35,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       getRepoConfigSpy.calledTwice.should.be.ok();
       getRepoConfigSpy.getCall(0).calledWith('repo1').should.be.ok();
@@ -52,7 +52,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       createDeployTemporaryBranchSpy.calledTwice.should.be.ok();
       createDeployTemporaryBranchSpy.getCall(0).calledWith('repo1').should.be.ok();
@@ -69,7 +69,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       pullRequestsFromChangesSpy.calledTwice.should.be.ok();
       pullRequestsFromChangesSpy.getCall(0).calledWith({ repo: 'repo1', head: 'deploy-123' }).should.be.ok();
@@ -88,7 +88,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       deployInfoFromPullRequestsSpy.calledTwice.should.be.ok();
       deployInfoFromPullRequestsSpy.getCall(0).calledWith('repo1', [ '890' ]).should.be.ok();
@@ -108,7 +108,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       issueReleaseInfoListSpy.calledTwice.should.be.ok();
       issueReleaseInfoListSpy.getCall(0).calledWith('repo1', [ '890' ]).should.be.ok();
@@ -123,7 +123,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       notifyStub.calledOnce.should.be.ok();
       done();
@@ -137,7 +137,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = true;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       notifyStub.calledTwice.should.be.ok();
       done();
@@ -154,7 +154,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       cleanUpDeploySpy.calledTwice.should.be.ok();
       done();
@@ -167,7 +167,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       const firstRepo = notifyStub.firstCall.args[0][0];
       firstRepo.failReason.should.be.eql('NO_SERVICES');
@@ -183,7 +183,7 @@ describe('start deploy action', () => {
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
-    startDeploy(repos, showPreview, (err) => {
+    startDeploy({ repos, showPreview }, (err) => {
       should.not.exist(err);
       const firstRepo = notifyStub.firstCall.args[0][0];
       firstRepo.failReason.should.be.eql('REPO_DEPLOY_FAILED');
@@ -258,7 +258,7 @@ describe('start deploy action', () => {
   }
 
   function createNotifyStub() {
-    const notify = (reposInfo, notificationName, cb) => cb();
+    const notify = (reposInfo, notificationName, verbose, cb) => cb();
     return sinon.spy(notify);
   }
 

--- a/test/core/services/notify_spec.js
+++ b/test/core/services/notify_spec.js
@@ -11,7 +11,8 @@ describe('notify service', () => {
 
     const reposInfo = [];
     const notificationName = 'non existing name';
-    notify(reposInfo, notificationName, (err) => {
+    const verbose = true;
+    notify(reposInfo, notificationName, verbose, (err) => {
       should.exist(err);
       err.message.should.be.eql('No template defined for this notification name');
       done();
@@ -23,7 +24,8 @@ describe('notify service', () => {
 
     const reposInfo = [];
     const notificationName = 'preview';
-    notify(reposInfo, notificationName, (err) => {
+    const verbose = true;
+    notify(reposInfo, notificationName, verbose, (err) => {
       should.exist(err);
       err.message.should.be.eql('There are no settings for this notification name');
       done();
@@ -37,7 +39,8 @@ describe('notify service', () => {
 
     const reposInfo = [];
     const notificationName = 'preview';
-    notify(reposInfo, notificationName, (err) => {
+    const verbose = true;
+    notify(reposInfo, notificationName, verbose, (err) => {
       should.not.exist(err);
       slackSpy.calledTwice.should.be.ok();
       slackSpy.firstCall.args[0].should.be.eql('preview-channel1');
@@ -58,7 +61,8 @@ describe('notify service', () => {
 
     const reposInfo = [];
     const notificationName = 'preview';
-    notify(reposInfo, notificationName, (err) => {
+    const verbose = true;
+    notify(reposInfo, notificationName, verbose, (err) => {
       should.not.exist(err);
       slackSpy.calledOnce.should.be.ok();
       slackSpy.firstCall.args[0].should.be.eql('preview-channel2');

--- a/test/presentation/slack/preview-release/preview_spec.js
+++ b/test/presentation/slack/preview-release/preview_spec.js
@@ -1,6 +1,6 @@
 'use scrict';
 
-require('should');
+const should = require('should');
 const createPreviewReleaseTemplate = require('../../../../presentation/slack/preview-release');
 const previewReleaseTemplate = createPreviewReleaseTemplate({ github: { user: 'AudienseCo' } });
 
@@ -15,7 +15,8 @@ describe('Preview Release Slack Notification Template', () => {
       failReason: 'NO_CHANGES'
     }];
     const filterLabels = [];
-    const msg = previewReleaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = previewReleaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text: 'PRs, services and issues that would be deployed with the next release...'
@@ -52,7 +53,8 @@ describe('Preview Release Slack Notification Template', () => {
       failReason: 'another error'
     }];
     const filterLabels = [];
-    const msg = previewReleaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = previewReleaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text: 'PRs, services and issues that would be deployed with the next release...'
@@ -101,7 +103,8 @@ describe('Preview Release Slack Notification Template', () => {
       }
     }];
     const filterLabels = [];
-    const msg = previewReleaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = previewReleaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text: 'PRs, services and issues that would be deployed with the next release...'
@@ -144,7 +147,8 @@ describe('Preview Release Slack Notification Template', () => {
       }
     }];
     const filterLabels = ['notify-staff'];
-    const msg = previewReleaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = previewReleaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text: 'PRs, services and issues that would be deployed with the next release...'
@@ -163,5 +167,29 @@ describe('Preview Release Slack Notification Template', () => {
       }]
     });
   });
+
+  it('should not generate template if there are no changes for any repo and verbose is false', () => {
+    const releaseInfo = [{
+      repo: 'repo1',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo2',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo3',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo4',
+      failReason: 'NO_CHANGES'
+    }];
+    const filterLabels = [];
+    const verbose = false;
+    const msg = previewReleaseTemplate(releaseInfo, filterLabels, verbose);
+    should.not.exist(msg);
+  });
+
 
 });

--- a/test/presentation/slack/release/release_spec.js
+++ b/test/presentation/slack/release/release_spec.js
@@ -25,7 +25,8 @@ describe('Release Slack Notification Template', () => {
       failReason: 'another error'
     }];
     const filterLabels = [];
-    const msg = releaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text: 'Monorail will not deploy anything because there is no pull request linked to services to deploy.',
@@ -84,7 +85,8 @@ describe('Release Slack Notification Template', () => {
       }
     }];
     const filterLabels = [];
-    const msg = releaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text:
@@ -135,7 +137,8 @@ describe('Release Slack Notification Template', () => {
       }
     }];
     const filterLabels = ['notify-staff'];
-    const msg = releaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
     msg.should.be.eql({
       attachments: [{
         text:
@@ -186,7 +189,8 @@ describe('Release Slack Notification Template', () => {
       }
     }];
     const filterLabels = ['notify-staff'];
-    const msg = releaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
     should.not.exist(msg);
   });
 
@@ -225,7 +229,33 @@ describe('Release Slack Notification Template', () => {
       issues: []
     }];
     const filterLabels = ['notify-staff'];
-    const msg = releaseTemplate(releaseInfo, filterLabels);
+    const verbose = true;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
+    should.not.exist(msg);
+  });
+
+  it('should not generate template if there are no changes for any repo and verbose is false', () => {
+    const releaseTemplate = createReleaseTemplate({ github: { user: 'AudienseCo' } });
+
+    const releaseInfo = [{
+      repo: 'repo1',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo2',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo3',
+      failReason: 'NO_CHANGES'
+    },
+    {
+      repo: 'repo4',
+      failReason: 'NO_CHANGES'
+    }];
+    const filterLabels = [];
+    const verbose = false;
+    const msg = releaseTemplate(releaseInfo, filterLabels, verbose);
     should.not.exist(msg);
   });
 

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -98,7 +98,8 @@ module.exports = function(actions) {
   });
 
   app.get('/slack-preview-release', (req, res) => {
-    actions.slackPreviewRelease((err) => {
+    const verbose = req.query.verbose || false;
+    actions.slackPreviewRelease({ verbose }, (err) => {
       if (err) {
         console.error('Error', err);
         return res.status(400).send(err);
@@ -111,8 +112,9 @@ module.exports = function(actions) {
   app.get('/deploy', (req, res) => {
     const showPreview = req.query.showPreview || false;
     const repos = req.query.repos || config.github.repos;
+    const verbose = req.query.verbose || false;
     console.info('Deploy started');
-    actions.startDeploy(repos, showPreview, (err) => {
+    actions.startDeploy({ repos, showPreview, verbose }, (err) => {
       if (err) {
         console.error('Error', err);
       }


### PR DESCRIPTION
This PR adds a `verbose` param to the `/slack-preview-release` and `/deploy` private endpoints.

- `verbose=true`:
If `verbose` is `true` the release preview notification in Slack will be published for all repositories even if there are no changes and nothing will be deployed.
- `verbose=`:
If `verbose` is not set the release preview notification in Slack won't show anything if there are no changes of any of the repositories.
