### PR TITLE
Add Logger

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,5 +11,8 @@ module.exports = {
   slack: {
     channel: 'monorail-tests',
     webhookUrl: process.env.SLACK_URL || ''
+  },
+  logger: {
+    level: 'error'
   }
 };

--- a/core/actions/slackPreviewRelease.js
+++ b/core/actions/slackPreviewRelease.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { waterfall, mapSeries } = require('async');
+const logger = require('../../lib/logger');
 
 module.exports = function createPreviewRelease(getConfig, getReleasePreview, notify, repos) {
 
@@ -16,7 +17,7 @@ module.exports = function createPreviewRelease(getConfig, getReleasePreview, not
     mapSeries(repos, (repo, nextRepo) => {
       getConfig(repo, (err, config) => {
         if (err) {
-          console.error('Error getting repo config', repo, err);
+          logger.error('Error getting repo config', repo, err);
           return nextRepo(null, { repo, failReason: 'INVALID_REPO_CONFIG' });
         }
         nextRepo(null, { repo, config });

--- a/core/actions/slackPreviewRelease.js
+++ b/core/actions/slackPreviewRelease.js
@@ -14,6 +14,7 @@ module.exports = function createPreviewRelease(getConfig, getReleasePreview, not
   };
 
   function getConfigForEachRepo(repos, cb) {
+    logger.debug('getConfigForEachRepo', { repos });
     mapSeries(repos, (repo, nextRepo) => {
       getConfig(repo, (err, config) => {
         if (err) {
@@ -26,6 +27,7 @@ module.exports = function createPreviewRelease(getConfig, getReleasePreview, not
   }
 
   function notifyPreviewInSlack(reposInfo, verbose, cb) {
+    logger.debug('notifyPreviewInSlack', { reposInfo, verbose });
     notify(reposInfo, 'preview', verbose, cb);
   }
 };

--- a/core/actions/startDeploy.js
+++ b/core/actions/startDeploy.js
@@ -30,6 +30,7 @@ module.exports = (
     });
 
     function getConfigForEachRepo(repos, cb) {
+      logger.debug('getConfigForEachRepo', { repos });
       mapSeries(repos, (repo, nextRepo) => {
         getConfig(repo, (err, config) => {
           if (err) {
@@ -42,6 +43,7 @@ module.exports = (
     }
 
     function createTemporaryBranchesForEachRepo(reposInfo, cb) {
+      logger.debug('createTemporaryBranchesForEachRepo', reposInfo);
       mapSeries(reposInfo, (repoInfo, nextRepo) => {
         if (repoInfo.failReason) return nextRepo(null, repoInfo);
         const devBranch = get(repoInfo, 'config.github.devBranch');
@@ -56,11 +58,13 @@ module.exports = (
     }
 
     function notifyPreviewSlackIfEnabled(showPreview, reposInfo, verbose, cb) {
+      logger.debug('notifyPreviewSlackIfEnabled', { showPreview, reposInfo, verbose });
       if (!showPreview) return cb(null, reposInfo);
       notify(reposInfo, 'preview', verbose, err => cb(err, reposInfo));
     }
 
     function deployEachRepo(reposInfo, cb) {
+      logger.debug('deployEachRepo', reposInfo);
       mapSeries(reposInfo, (repoInfo, nextRepo) => {
         if (repoInfo.failReason) {
           cleanUpDeploy(repoInfo, err => {
@@ -80,6 +84,7 @@ module.exports = (
     }
 
     function notifyRelease(reposInfo, cb) {
+      logger.debug('notifyRelease', reposInfo);
       notify(reposInfo, 'release', verbose, err => cb(err, reposInfo));
     }
 

--- a/core/services/build.js
+++ b/core/services/build.js
@@ -2,6 +2,7 @@
 
 const { eachSeries } = require('async');
 const { get, assignWith, cloneDeep, isNil, defaultsDeep } = require('lodash');
+const logger = require('../../lib/logger');
 
 module.exports = (callCIDriver) => {
   return (branch, jobs, deployConfig,  cb) => {
@@ -10,19 +11,19 @@ module.exports = (callCIDriver) => {
 
       const ciServiceName = get(deployConfig, `ciJobs['${job.name}'].ciService`);
       if (!ciServiceName) {
-        console.error(`Not valid config for job: ${job.name}`)
+        logger.error(`Not valid config for job: ${job.name}`)
         return nextJob();
       }
 
       const ciService = get(deployConfig, `ciServices['${ciServiceName}']`);
       if (!ciService) {
-        console.error(`Not valid config for ciService: ${ciServiceName}`)
+        logger.error(`Not valid config for ciService: ${ciServiceName}`)
         return nextJob();
       }
 
       const finalCIJob = combineCIJobConfigs(job, branch, deployConfig);
       if (!finalCIJob) {
-        console.error(`Not valid config for ciJob: ${job.name}`)
+        logger.error(`Not valid config for ciJob: ${job.name}`)
         return nextJob();
       }
 

--- a/core/services/checkers/deploy-labels/deployLabelsService.js
+++ b/core/services/checkers/deploy-labels/deployLabelsService.js
@@ -1,10 +1,12 @@
 'use strict';
 const async = require('async');
+const logger = require('../../../../lib/logger');
 
 module.exports = function createDeployNotesService(deployLabelsChecker, github) {
   const that = {};
 
   that.updatePullRequestCommit = (repo, prInfo) => {
+    logger.debug('updatePullRequestCommit', { repo, prInfo });
     async.waterfall([
       function check(next) {
         deployLabelsChecker.checkPullRequest(repo, prInfo, next);
@@ -18,8 +20,8 @@ module.exports = function createDeployNotesService(deployLabelsChecker, github) 
         status.sha = pr.head.sha;
         status.repo = repo;
         github.updateCommitStatus(status, (err, result) => {
-          if (err) console.log('Update commit state error', err);
-          else console.log('Updated commit state');
+          if (err) logger.error('Update commit state error', err, { status, pr });
+          else logger.info('Updated commit state');
         });
       }
     ]);

--- a/core/services/checkers/deploy-notes/deployNotesService.js
+++ b/core/services/checkers/deploy-notes/deployNotesService.js
@@ -1,5 +1,6 @@
 'use strict';
 const async = require('async');
+const logger = require('../../../../lib/logger');
 
 module.exports = function createDeployNotesService(deployNotesChecker, github) {
   const that = {};
@@ -18,8 +19,8 @@ module.exports = function createDeployNotesService(deployNotesChecker, github) {
         status.sha = pr.head.sha;
         status.repo = repo;
         github.updateCommitStatus(status, (err, result) => {
-          if (err) console.log('Update commit state error', err);
-          else console.log('Updated commit state');
+          if (err) logger.error('Update commit state error', err, { status, pr });
+          else logger.info('Updated commit state');
         });
       }
     ]);

--- a/core/services/checkers/qa-review/qaReviewService.js
+++ b/core/services/checkers/qa-review/qaReviewService.js
@@ -1,5 +1,6 @@
 'use strict';
 const async = require('async');
+const logger = require('../../../../lib/logger');
 
 module.exports = function(qaReviewChecker, github) {
   const that = {};
@@ -18,8 +19,8 @@ module.exports = function(qaReviewChecker, github) {
         status.sha = pr.head.sha;
         status.repo = repo;
         github.updateCommitStatus(status, (err, result) => {
-          if (err) console.log('Update commit state error', err);
-          else console.log('Updated commit state');
+          if (err) logger.error('Update commit state error', err, { status, pr });
+          else logger.info('Updated commit state');
         });
       }
     ]);

--- a/core/services/getReleasePreview.js
+++ b/core/services/getReleasePreview.js
@@ -2,6 +2,7 @@
 
 const { mapSeries, waterfall } = require('async');
 const { get } = require('lodash');
+const logger = require('../../lib/logger');
 
 module.exports = (
   pullRequestsFromChanges,
@@ -20,7 +21,7 @@ module.exports = (
     mapSeries(reposInfo, (repoInfo, nextRepo) => {
       pullRequestsFromChanges({ repo: repoInfo.repo, head: repoInfo.branch }, (err, prIds) => {
         if (err) {
-          console.error('Error pull requests from changes', repoInfo.repo, err);
+          logger.error('Error pull requests from changes', repoInfo.repo, err);
           return nextRepo(null, Object.assign({}, repoInfo, { failReason: 'PRS_RETRIEVING_FAILURE' }));
         }
         nextRepo(null, Object.assign({}, repoInfo, { prIds }));
@@ -38,7 +39,7 @@ module.exports = (
       deployInfoFromPullRequests(repoInfo.repo, repoInfo.prIds, repoConfig, (err, deployInfo) => {
         let failReason;
         if (err) {
-          console.error('Error getting deploy info form PRs', repoInfo.repo, err);
+          logger.error('Error getting deploy info form PRs', repoInfo.repo, err);
           failReason = err.message;
         }
         else if (deployInfo.deployNotes) {
@@ -56,7 +57,7 @@ module.exports = (
     mapSeries(reposInfo, (repoInfo, nextRepo) => {
       issueReleaseInfoList.get(repoInfo.repo, repoInfo.prIds, (err, issuesInfo) => {
         if (err) {
-          console.error('Error getting issues to release', repoInfo.repo, err);
+          logger.error('Error getting issues to release', repoInfo.repo, err);
           return nextRepo(null, Object.assign({}, repoInfo, { failReason: 'ISSUES_RETRIEVING_FAILURE' }));
         }
         const issuesReleaseInfo = issuesInfo.map(issueInfo => ({

--- a/core/services/issueReleaseInfo.js
+++ b/core/services/issueReleaseInfo.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var async = require('async');
+const async = require('async');
+const logger = require('../../lib/logger');
 
 module.exports = function(github, boundIssueExtractor, issueParticipants) {
   const that = {};
@@ -9,10 +10,12 @@ module.exports = function(github, boundIssueExtractor, issueParticipants) {
     async.waterfall([
 
       function getPRInfo(next) {
+        logger.debug('getPRInfo', { repo, prId });
         github.getIssue(repo, prId, next);
       },
 
       function getBoundIssue(prInfo, next) {
+        logger.debug('getBoundIssue', { repo, prId, prInfo });
         const boundIssue = boundIssueExtractor.extract(prInfo.body);
         if (!boundIssue) return next(null, [prInfo]);
 
@@ -22,6 +25,7 @@ module.exports = function(github, boundIssueExtractor, issueParticipants) {
       },
 
       function getParticipants(issueList, next) {
+        logger.debug('getParticipants', { repo, prId, issueList });
         issueParticipants.getParticipants(repo, issueList, (err, participants) => {
           next(err, issueList, participants);
         });

--- a/core/services/issueReleaseInfoList.js
+++ b/core/services/issueReleaseInfoList.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const async = require('async');
+const logger = require('../../lib/logger');
 
 module.exports = function issueReleaseInfoListBuilder(issueReleaseInfo) {
   const that = {};
 
   that.get = (repo, ids, callback) => {
     async.map(ids, (id, nextId) => {
+      logger.debug('issueReleaseInfo.getInfo', { repo, id });
       issueReleaseInfo.getInfo(repo, id, (err, issueReleaseInfo) => {
         nextId(err, issueReleaseInfo);
       });

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const EventEmitter        = require('events');
 const createPublicWebApp  = require('./web/public');
 const createPrivateWebApp = require('./web/private');
 const actions             = require('./core/actions');
+const logger              = require('./lib/logger');
 
 const emitter = new EventEmitter();
 const githubSecret = process.env.GH_SECRET;
@@ -15,12 +16,12 @@ actions.subscribeCheckersToEvents(emitter);
 
 const publicPort = process.env.PORT || 8080;
 publicWebApp.listen(publicPort, err => {
-  if (err) console.error('Error starting the public server', err);
-  else console.info(`Listening public server in ${publicPort}`);
+  if (err) logger.error('Error starting the public server', err);
+  else logger.info(`Listening public server in ${publicPort}`);
 });
 
 const privatePort = process.PRIVATE_PORT || 8484;
 privateWebApp.listen(privatePort, err => {
-  if (err) console.error('Error starting the private server', err);
-  else console.info(`Listening private server in ${privatePort}`);
+  if (err) logger.error('Error starting the private server', err);
+  else logger.info(`Listening private server in ${privatePort}`);
 });

--- a/lib/ciDrivers/jenkins/jenkins.js
+++ b/lib/ciDrivers/jenkins/jenkins.js
@@ -2,6 +2,7 @@
 
 const { URL } = require('url');
 const { waterfall, doUntil } = require('async');
+const logger = require('../../../lib/logger');
 
 module.exports = (jenkinsApi) => {
   let jenkins;
@@ -13,7 +14,7 @@ module.exports = (jenkinsApi) => {
       jenkins = createClient(settings);
     }
     catch (err) {
-      console.error('Error creating jenkins client', err);
+      logger.error('Error creating jenkins client', err);
       return cb(new Error('Invalid jenkins settings'));
     }
 

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -1,0 +1,21 @@
+
+const winston = require('winston');
+const { combine, simple, timestamp } = winston.format;
+const { logger: loggerSettings } = require('../../config');
+const createLogger = require('./logger');
+
+function createWinstonLogger({ level }) {
+  const winstonLogger = winston.createLogger({
+    format: combine(
+      timestamp(),
+      simple()
+    ),
+    transports: [
+      new winston.transports.Console()
+    ]
+  });
+  if (level) winstonLogger.level = level;
+  return winstonLogger
+}
+
+module.exports = createLogger(loggerSettings, createWinstonLogger);

--- a/lib/logger/logger.js
+++ b/lib/logger/logger.js
@@ -1,0 +1,22 @@
+
+module.exports = (settings, createLogger) => {
+  const logger = createLogger(settings);
+
+  function error() {
+    logger.error(...arguments);
+  };
+
+  function info() {
+    logger.info(...arguments);
+  };
+
+  function debug() {
+    logger.debug(...arguments);
+  };
+
+  return {
+    error,
+    info,
+    debug
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,11 +357,19 @@
         "supports-color": "5.4.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "1.9.3",
+        "color-string": "1.5.3"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -369,8 +377,35 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.0",
+        "text-hex": "1.0.0"
+      }
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -448,6 +483,16 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.2",
+        "enabled": "1.0.2",
+        "kuler": "1.0.1"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -459,10 +504,23 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.5"
+      }
+    },
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "es-abstract": {
       "version": "1.13.0",
@@ -562,6 +620,16 @@
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
       }
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "finalhandler": {
       "version": "1.1.0",
@@ -747,6 +815,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
       "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -829,10 +902,37 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "1.1.1"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "1.3.3",
+        "fast-safe-stringify": "2.0.6",
+        "fecha": "2.3.3",
+        "ms": "2.1.2",
+        "triple-beam": "1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -2146,6 +2246,11 @@
         "wrappy": "1.0.2"
       }
     },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -2334,6 +2439,14 @@
       "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "0.3.2"
+      }
+    },
     "sinon": {
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
@@ -2351,6 +2464,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
       "version": "1.4.0",
@@ -2374,6 +2492,11 @@
         "has-flag": "3.0.0"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2385,6 +2508,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "type-is": {
       "version": "1.6.15",
@@ -2431,6 +2559,88 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "2.6.2",
+        "diagnostics": "1.1.1",
+        "is-stream": "1.1.0",
+        "logform": "2.1.2",
+        "one-time": "0.0.4",
+        "readable-stream": "3.4.0",
+        "stack-trace": "0.0.10",
+        "triple-beam": "1.3.0",
+        "winston-transport": "4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "4.17.11"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.2.0",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "triple-beam": "1.3.0"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "github": "^0.2.4",
     "jenkins": "^0.25.0",
     "lodash": "^4.17.11",
-    "morgan": "^1.7.0"
+    "morgan": "^1.7.0",
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/test/lib/logger/builder_spec.js
+++ b/test/lib/logger/builder_spec.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('should');
+const logger = require('../../../lib/logger');
+
+describe('Logger builder', () => {
+  context('Interface', () => {
+    it('should have the "error" method', () => {
+      logger.error.should.be.a.Function();
+    });
+    it('should have the "info" method', () => {
+      logger.info.should.be.a.Function();
+    });
+    it('should have the "debug" method', () => {
+      logger.debug.should.be.a.Function();
+    });
+  });
+
+  context('Behaviour', () => {
+    it('should call the logger succesfully', () => {
+      logger.error('test', { a: 'b'}, [1,2,3]);
+    });
+  });
+
+});

--- a/test/lib/logger/logger_spec.js
+++ b/test/lib/logger/logger_spec.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('should');
+const sinon = require('sinon');
+const createLogger = require('../../../lib/logger/logger');
+
+describe('Logger wrapper', () => {
+  it('should call the logger with the same parameters', () => {
+    const settings = {};
+    const debugStub = sinon.stub();
+    const createLoggerStub = () => {
+      return {
+        debug: debugStub
+      };
+    };
+
+    const logger = createLogger(settings, createLoggerStub);
+    logger.debug('test', { a: '123' }, [ 1, 2, 4]);
+    debugStub.withArgs('test', { a: '123' }, [ 1, 2, 4]).calledOnce.should.be.ok();
+  });
+});

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -4,6 +4,8 @@ const express = require('express');
 const morgan  = require('morgan');
 const bodyParser = require('body-parser');
 const config = require('../../config');
+const logger = require('../../lib/logger');
+
 
 module.exports = function(actions) {
   const app = express();
@@ -21,7 +23,7 @@ module.exports = function(actions) {
     const verbose = req.query.verbose || false;
     actions.slackPreviewRelease({ verbose }, (err) => {
       if (err) {
-        console.error('Error', err);
+        logger.error('Error', err);
         return res.status(400).send(err);
       }
       res.status(200).send('OK');
@@ -33,12 +35,12 @@ module.exports = function(actions) {
     const showPreview = req.query.showPreview || false;
     const repos = req.query.repos || config.github.repos;
     const verbose = req.query.verbose || false;
-    console.info('Deploy started');
+    logger.info('Deploy started');
     actions.startDeploy({ repos, showPreview, verbose }, (err) => {
       if (err) {
-        console.error('Error', err);
+        logger.error('Error', err);
       }
-      console.info('Deploy finished');
+      logger.info('Deploy finished');
     });
 
     res.status(202).send('Accepted');

--- a/web/public/index.js
+++ b/web/public/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const morgan  = require('morgan');
 const bodyParser = require('body-parser');
 const crypto = require('crypto');
+const logger = require('../../lib/logger');
 
 module.exports = function(eventEmitter, secret) {
   const app = express();
@@ -27,10 +28,10 @@ module.exports = function(eventEmitter, secret) {
       const signature = req.get('x-hub-signature');
       const computedSignature = signBlob(secret, buffer);
 
-      console.log('verified', signature, computedSignature);
+      logger.debug('verified', signature, computedSignature);
 
       if (signature !== computedSignature) {
-        console.warn('Recieved an invalid HMAC: calculated:' +
+        logger.error('Recieved an invalid HMAC: calculated:' +
           computedSignature + ' != recieved:' + signature);
         throw new Error('Invalid Signature');
       }
@@ -49,7 +50,7 @@ module.exports = function(eventEmitter, secret) {
       res.status(200).send('ok');
     }
     catch (ex) {
-      console.log('ghwebook public endpoint error', ex);
+      logger.error('ghwebook public endpoint error', ex, { payload: req.body.payload });
       res.status(500).send(ex);
     }
 


### PR DESCRIPTION
- Add a logger infrastructure service
- Substitute direct `console` usage by the logger service
- Add some debug logs.
- Add new `logger` settings section to config:
```
logger: {
  'level': 'error'
}
```
Currently supported logging levels are `error`, `info` and `debug`. 
By default it is configured are `error`, so only errors will be logged. Override it in your production setup.