### PR TITLE
Avoid deploying if there is a deploy in progress

### DIFF
--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -8,6 +8,8 @@ const checkers = [
   require('../services/checkers/deploy-labels')
 ];
 
+const deploysController = require('../services/deploysController')();
+
 const github = require('../../lib/github');
 const slack = require('../../lib/slack');
 const pullRequestDeployInfo = require('../services/pullRequestDeployInfo')(github);
@@ -31,7 +33,7 @@ const getReleasePreview = require('../services/getReleasePreview')(
   issueReleaseInfoList
 );
 
-const slackTemplates = require('../../presentation/slack')(config);
+const slackTemplates = require('../../presentation/slack')(config, deploysController);
 const notify = require('../services/notify')(slackTemplates, slack, config);
 
 const clock = require('../../lib/clock')();
@@ -55,7 +57,6 @@ const deploy = require('../services/deploy')(
 );
 const cleanUpDeploy = require('../services/cleanUpDeploy')(github);
 
-
 module.exports = {
   subscribeCheckersToEvents: require('./subscribeCheckersToEvents')(checkers),
   slackPreviewRelease: require('./slackPreviewRelease')(
@@ -64,6 +65,7 @@ module.exports = {
     notify
   ),
   startDeploy: require('./startDeploy')(
+    deploysController,
     getConfig,
     createDeployTemporaryBranch,
     getReleasePreview,

--- a/core/actions/startDeploy.js
+++ b/core/actions/startDeploy.js
@@ -5,6 +5,7 @@ const { get } = require('lodash');
 const logger = require('../../lib/logger');
 
 module.exports = (
+  deploysController,
   getConfig,
   createDeployTemporaryBranch,
   getReleasePreview,
@@ -13,6 +14,8 @@ module.exports = (
   notify
 ) => {
   return ({ repos, showPreview, verbose = false }, cb) => {
+    if (deploysController.isBusy()) return cb(new Error('DEPLOY_IN_PROGRESS'));
+
     waterfall([
       (next)            => getConfigForEachRepo(repos, next),
       (reposInfo, next) => createTemporaryBranchesForEachRepo(reposInfo, next),

--- a/core/services/deploysController.js
+++ b/core/services/deploysController.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = () => {
+  let busy = false;
+
+  function start() {
+    if (busy) throw new Error('DEPLOY_IN_PROGRESS');
+    busy = true;
+  }
+
+  function finish() {
+    busy = false;
+  }
+
+  function isBusy() {
+    return busy;
+  }
+
+  return {
+    start,
+    finish,
+    isBusy
+  };
+}

--- a/presentation/slack/index.js
+++ b/presentation/slack/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (config) => ({
-  preview: require('./preview-release')(config),
+module.exports = (config, deploysController) => ({
+  preview: require('./preview-release')(config, deploysController),
   release: require('./release')(config)
 });

--- a/presentation/slack/preview-release/index.js
+++ b/presentation/slack/preview-release/index.js
@@ -4,7 +4,7 @@ const { get } = require('lodash') ;
 const ERROR_TEMPLATES = require('./errors');
 const releasePreviewMsg = require('./release-preview');
 
-module.exports = module.exports = (config) => {
+module.exports = module.exports = (config, deploysController) => {
   return (releasePreview, filterLabels, verbose) => {
     const user = get(config, 'github.user');
 
@@ -27,6 +27,12 @@ module.exports = module.exports = (config) => {
       attachments.unshift({
         text: 'PRs, services and issues that would be deployed with the next release...'
       });
+      if (deploysController.isBusy()) {
+        attachments.unshift({
+          text: 'There is a deploy in progress.',
+          color: 'danger'
+        });
+      }
       return {
         attachments
       };

--- a/test/core/actions/startDeploy_spec.js
+++ b/test/core/actions/startDeploy_spec.js
@@ -19,6 +19,7 @@ const createReleaseService = require('../../../core/services/releaseService');
 const createMergeDeployBranch = require('../../../core/services/mergeDeployBranch');
 const createDeploy = require('../../../core/services/deploy');
 const createCleanUpDeploy = require('../../../core/services/cleanUpDeploy');
+const createDeploysController = require('../../../core/services/deploysController');
 const createStartDeploy = require('../../../core/actions/startDeploy');
 
 describe('start deploy action', () => {
@@ -192,8 +193,9 @@ describe('start deploy action', () => {
   });
 
   it('it should avoid starting deploys if there is one already running', (done) => {
-    const deploysController = createDeploysController({ busy: true });
+    const deploysController = createDeploysController();
     const startDeploy = createStartDeployWithStubs({ deploysController });
+    deploysController.start();
 
     const repos = ['repo1', 'repo2'];
     const showPreview = false;
@@ -201,6 +203,20 @@ describe('start deploy action', () => {
       should.exist(err);
       err.message.should.be.eql('DEPLOY_IN_PROGRESS');
       done();
+    });
+  });
+
+  it('it should allow starting deploys after finishing another one', (done) => {
+    const deploysController = createDeploysController();
+    const startDeploy = createStartDeployWithStubs({ deploysController });
+    const repos = ['repo1', 'repo2'];
+    const showPreview = false;
+    startDeploy({ repos, showPreview }, (err) => {
+      should.not.exist(err);
+      startDeploy({ repos, showPreview }, (err) => {
+        should.not.exist(err);
+        done();
+      });
     });
   });
 
@@ -275,12 +291,6 @@ describe('start deploy action', () => {
     return sinon.spy(notify);
   }
 
-  function createDeploysController({ busy = false }) {
-    return {
-      isBusy: () => busy
-    };
-  }
-
   function createStartDeployWithStubs({
     deploysController,
     createDeployTemporaryBranch,
@@ -296,7 +306,7 @@ describe('start deploy action', () => {
     notify,
     github
   }) {
-    const deploysControllerStub = deploysController || createDeploysController({});
+    const deploysControllerStub = deploysController || createDeploysController();
     const githubDummy = github || createGithubDummy();
     const getRepoConfigStub = getRepoConfig || createGetRepoConfig(githubDummy);
     const createDeployTemporaryBranchStub = createDeployTemporaryBranch || createCreateDeployTemporaryBranch(githubDummy, clock);

--- a/test/core/services/deploysController_spec.js
+++ b/test/core/services/deploysController_spec.js
@@ -1,0 +1,24 @@
+'use strict';
+require('should');
+const createDeploysController = require('../../../core/services/deploysController');
+
+describe('deploys crontroller service', () => {
+  it('should not allow to start if there is a deploy in progress', () => {
+    const deploysController = createDeploysController();
+    deploysController.start();
+    deploysController.isBusy().should.be.true();
+    (() => {
+      deploysController.start();
+    }).should.throw('DEPLOY_IN_PROGRESS');
+  });
+
+  it('should allow to start if there is the deploy finished', () => {
+    const deploysController = createDeploysController();
+    deploysController.start();
+    deploysController.isBusy().should.be.true();
+    deploysController.finish();
+    deploysController.isBusy().should.be.false();
+    deploysController.start();
+  });
+
+});

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -40,6 +40,9 @@ module.exports = function(actions) {
     actions.startDeploy({ repos, showPreview, verbose }, (err) => {
       if (err) {
         logger.error('Error', err);
+        if (err.message === 'DEPLOY_IN_PROGRESS') {
+          return res.status(429).send(err);
+        } else return res.status(400).send(err);
       }
       logger.info('Deploy finished');
     });


### PR DESCRIPTION
Fixes #53 
After this PR if you call the `/deploy` endpoint while there is a deploy in progress it will respond with a `429` HTTP error.
Also now the release preview will notify if there is a deploy in progress. 
