### PR TITLE
Return slack message payload from release preview endpoint

### DIFF
--- a/core/services/notify.js
+++ b/core/services/notify.js
@@ -10,11 +10,13 @@ module.exports = (templates, slack, config) => {
     const notificationSettings = get(config, `slack.notifications['${notificationName}']`);
     if (!notificationSettings) return cb(new Error('There are no settings for this notification name'));
 
+    const msgs = {};
     eachSeries(notificationSettings, (channelInfo, next) => {
       const msg = template(reposInfo, channelInfo.labels, verbose);
       if (!msg) return next();
       // TODO: publish verbose errors in another channel
+      msgs[channelInfo.channel] = msg;
       slack.send(channelInfo.channel, msg, next);
-    }, cb);
+    }, err => cb(err, msgs));
   };
 }

--- a/web/private/index.js
+++ b/web/private/index.js
@@ -22,12 +22,14 @@ module.exports = function(actions) {
   app.get('/slack-preview-release', (req, res) => {
     const verbose = req.query.verbose || false;
     const repos = req.query.repos || config.github.repos;
-    actions.slackPreviewRelease({ repos, verbose }, (err) => {
+    actions.slackPreviewRelease({ repos, verbose }, (err, msgs) => {
       if (err) {
         logger.error('Error', err);
         return res.status(400).send(err);
       }
-      res.status(200).send('OK');
+      res.status(200).json({
+        slack_messages: msgs
+      });
     });
 
   });


### PR DESCRIPTION
After merging this PR the `/slack-preview-release` endpoint will respond with slack messages payload as JSON, one per configured channel). It will return an object like
```
{
  slack_messages: {
    "dev": {
      attachments: [{
        text: 'PRs, services and issues that would be deployed with the next release...'
      },{
        text: 'Monorail will not deploy anything in the next 10 minutes as there have not been changes since the last deploy.',
        color: '#439FE0',
        title: 'repo3',
        title_link: 'https://github.com/AudienseCo/repo3'
      },
      {
        text: 'Monorail will not deploy anything in the next 10 minutes as there have not been changes since the last deploy.',
        color: '#439FE0',
        title: 'repo4',
        title_link: 'https://github.com/AudienseCo/repo4'
      }]
    }
  }
}
```


 For more payload examples see this tests: https://github.com/AudienseCo/monorail/blob/master/test/presentation/slack/preview-release/preview_spec.js#L20