### PR TITLE
Use commit statuses instead of checks

### DIFF
--- a/core/services/getBranchStatus.js
+++ b/core/services/getBranchStatus.js
@@ -2,7 +2,7 @@
 
 const logger = require('../../lib/logger');
 
-const { find, map } = require('lodash');
+const { find } = require('lodash');
 const { waterfall } = require('async');
 
 module.exports = (github, POLLING_INTERVAL_MS) => {

--- a/lib/github/github.js
+++ b/lib/github/github.js
@@ -89,6 +89,11 @@ module.exports = function(githubApi, config) {
     callbackify(githubApi.checks.listForRef)(msg, (err, res) => handleResponse(err, res, cb));
   };
 
+  that.getStatusesForRef = (repo, ref, cb) => {
+    const msg = Object.assign({}, buildMsg({ repo, ref }));
+    callbackify(githubApi.repos.listStatusesForRef)(msg, (err, res) => handleResponse(err, res, cb));
+  };
+
   function buildMsg(options) {
     const defaults = {
       owner: config.owner,

--- a/test/core/services/getBranchStatus_spec.js
+++ b/test/core/services/getBranchStatus_spec.js
@@ -221,14 +221,12 @@ describe('get branch status service', () => {
       getProtectedBranchRequiredStatusChecksRes: {
         contexts: ['node/check1', 'node/check3']
       },
-      getChecksForRefRes: {
-        check_runs: [
-          { context: 'check1', state: 'failed' },
-          { context: 'check2', state: 'failed' },
-          { context: 'check3', state: 'success' },
-          { context: 'check1', state: 'success' }
-        ]
-      }
+      getStatusesForRefRes: [
+          { context: 'node/check1', state: 'failed' },
+          { context: 'node/check2', state: 'failed' },
+          { context: 'node/check3', state: 'success' },
+          { context: 'node/check1', state: 'success' }
+      ]
     });
     const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
 

--- a/test/lib/github/github_spec.js
+++ b/test/lib/github/github_spec.js
@@ -68,6 +68,10 @@ describe('Github API wrapper', () => {
       github.getChecksForRef.should.be.a.Function();
     });
 
+    it('should have the "getStatusesForRef" method', () => {
+      github.getStatusesForRef.should.be.Function();
+    })
+
     it('should have the "getCommitStatus" method', () => {
       github.getCommitStatus.should.be.a.Function();
     });
@@ -117,6 +121,9 @@ describe('Github API wrapper', () => {
           },
           getProtectedBranchRequiredStatusChecks: (repo, branch, cb) => {
             return responsePromise;
+          },
+          listStatusesForRef: (repo, branch, cb) => {
+            return responsePromise
           }
         },
         git: {
@@ -430,6 +437,24 @@ describe('Github API wrapper', () => {
       const repo = 'another';
       const ref = 'staging';
       github.getChecksForRef(repo, ref, (err, result) => {
+        spy.calledWith({
+          owner: 'AudienseCo',
+          repo: 'another',
+          ref: 'staging'
+        }).should.be.ok();
+        done();
+      });
+    });
+
+    it('get statuses for ref', done => {
+      const githubApiDummy = createGithubDummy({ id: 1234 });
+      const github = createGithub(githubApiDummy, config);
+      const spy = sinon.spy(githubApiDummy.repos, 'listStatusesForRef');
+
+      const repo = 'another';
+      const ref = 'staging';
+
+      github.getStatusesForRef(repo, ref, (err, result) => {
         spy.calledWith({
           owner: 'AudienseCo',
           repo: 'another',


### PR DESCRIPTION
External checks like monorail check labels and other CI tools out of github are not present in check list, they are present in the statuses for ref but with all the executions. The Github API return that statuses with the recent executions first.