### PR TITLE
Remove branch check status

### DIFF
--- a/core/services/getBranchStatus.js
+++ b/core/services/getBranchStatus.js
@@ -38,9 +38,9 @@ module.exports = (github, POLLING_INTERVAL_MS) => {
       if (err) return cb(err);
       logger.info(`INFO Checking status for ${repo} ${sha}`)
       const result = combineChecksResults(data.check_runs, requiredChecks);
-      if (!result.finished) {
-        return setTimeout(() => checkStatus(repo, sha, requiredChecks, cb), POLLING_INTERVAL_MS);
-      }
+      //if (!result.finished) {
+      //  return setTimeout(() => checkStatus(repo, sha, requiredChecks, cb), POLLING_INTERVAL_MS);
+      //}
       if (!result.succeeded) return cb(new Error('CHECKS_FAILED'));
       cb(null, sha);
     });
@@ -50,11 +50,10 @@ module.exports = (github, POLLING_INTERVAL_MS) => {
     return requiredChecks.reduce(({ finished, succeeded }, checkName) => {
       const check = find(checks, ['name', checkName]);
       if (!check) {
-        logger.info(`INFO Required check ${checkName} was not found`);
-        return { finished, succeeded: false };
+        logger.info(`INFO Required check ${checkName} was not found in commit status, so skipping it`);
+        return { finished: true, succeeded: true }
+        //return { finished, succeeded: false };
       }
-
-      logger.info(`INFO check ${checkName} finished: ${finished} status: ${check.status} conclusion: ${check.conclusion}`);
 
       return {
         finished: finished && check.status === 'completed',

--- a/core/services/getBranchStatus.js
+++ b/core/services/getBranchStatus.js
@@ -2,63 +2,14 @@
 
 const logger = require('../../lib/logger');
 
-const { find } = require('lodash');
-const { waterfall } = require('async');
-
-module.exports = (github, POLLING_INTERVAL_MS) => {
+module.exports = (github) => {
   return (repo, branch, cb) => {
-    waterfall([
-      (next) => github.getBranch(repo, branch, (err, data) => {
-        if (err) {
-          logger.error(`ERROR Getting branch for ${repo} ${branch}`, data)
-          return next(err);
-        }
-        next(null, data.object.sha);
-      }),
-      (sha, next) => github.getProtectedBranchRequiredStatusChecks(repo, branch, (err, data) => {
-        if (err && err.status === 404) {
-          logger.info(`INFO Branch is not protected ${repo} ${branch}`, data)
-          return next(null, sha, []);
-        }
-        else if (err) {
-          logger.error(`ERROR Getting protected branch required status for ${repo} ${branch} ${err.status}`, data)
-          return next(err);
-        }
-        next(null, sha, data.contexts);
-      }),
-      (sha, requiredChecks, next) => checkStatus(repo, sha, requiredChecks, next)
-    ], cb);
-  };
-
-  function checkStatus(repo, sha, requiredChecks, cb) {
-    if (!requiredChecks.length) {
-      return cb(null, sha)
-    }
-    github.getChecksForRef(repo, sha, (err, data) => {
-      if (err) return cb(err);
-      logger.info(`INFO Checking status for ${repo} ${sha}`)
-      const result = combineChecksResults(data.check_runs, requiredChecks);
-      //if (!result.finished) {
-      //  return setTimeout(() => checkStatus(repo, sha, requiredChecks, cb), POLLING_INTERVAL_MS);
-      //}
-      if (!result.succeeded) return cb(new Error('CHECKS_FAILED'));
-      cb(null, sha);
-    });
-  }
-
-  function combineChecksResults(checks, requiredChecks) {
-    return requiredChecks.reduce(({ finished, succeeded }, checkName) => {
-      const check = find(checks, ['name', checkName]);
-      if (!check) {
-        logger.info(`INFO Required check ${checkName} was not found in commit status, so skipping it`);
-        return { finished: true, succeeded: true }
-        //return { finished, succeeded: false };
+    github.getBranch(repo, branch, (err, data) => {
+      if (err) {
+        logger.error(`ERROR Getting branch for ${repo} ${branch} ${err.status}`, data)
+        return cb(err);
       }
-
-      return {
-        finished: finished && check.status === 'completed',
-        succeeded: succeeded && check.conclusion === 'success',
-      };
-    }, { finished: true, succeeded: true });
+      cb(null, data.object.sha);
+    })
   }
 };

--- a/test/core/services/getBranchStatus_spec.js
+++ b/test/core/services/getBranchStatus_spec.js
@@ -3,25 +3,18 @@
 const should = require('should');
 const sinon = require('sinon');
 const createGetBranchStatus = require('../../../core/services/getBranchStatus');
-const POLLING_INTERVAL_MS = 1;
 
 describe('get branch status service', () => {
-  it('should succeed when no checks required', (done) => {
+  it('should succeed when branch exists', (done) => {
     const aSha = '123';
     const githubDummy = createGithubDummy(null, {
       getBranchRes: {
         object: {
           sha: aSha
         }
-      },
-      getProtectedBranchRequiredStatusChecksError: {
-        status: 404
-      },
-      getChecksForRefRes: {
-        check_runs: []
       }
     });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
+    const getBranchStatus = createGetBranchStatus(githubDummy);
 
     const repo = 'audienseCo';
     const branch = 'staging';
@@ -41,54 +34,7 @@ describe('get branch status service', () => {
         object: {}
       }
     });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.exists(err);
-      githubDummy.wasCalled('getProtectedBranchRequiredStatusChecks').should.not.be.true();
-      done();
-    });
-  });
-
-  it('shouldnt call gitCheckForRef when no checks required', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksError: {
-        status: 404
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.not.exists(err);
-      sha.should.be.eql(aSha);
-      githubDummy.wasCalled('gitCheckForRef').should.not.be.true();
-      done();
-    });
-  });
-
-  it('should fail when github reply with status not equal to 200 or 404', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksError: {
-        status: 403
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
+    const getBranchStatus = createGetBranchStatus(githubDummy);
 
     const repo = 'audienseCo';
     const branch = 'staging';
@@ -98,212 +44,12 @@ describe('get branch status service', () => {
     });
   });
 
-
-  it('should succeed when no checks required or executed', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: []
-      },
-      getChecksForRefRes: {
-        check_runs: []
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.not.exists(err);
-      sha.should.be.eql(aSha);
-      done();
-    });
-  });
-
-  it('should succeed when all require checks have succeed and are completed', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: ['check1']
-      },
-      getChecksForRefRes: {
-        check_runs: [
-          { name: 'check1', status: 'completed', conclusion: 'success' },
-          { name: 'check2', status: 'completed', conclusion: 'failed' }
-        ]
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.not.exists(err);
-      sha.should.be.eql(aSha);
-      done();
-    });
-  });
-
-  it.skip('should wait when one of the require checks is not completed', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: ['check1', 'check3']
-      },
-      getChecksForRefRes: null
-    });
-    const stub = sinon.stub(githubDummy, 'getChecksForRef');
-    stub.onFirstCall().callsArgWith(2, null, {
-      check_runs: [
-        { name: 'check1', status: 'completed', conclusion: 'success' },
-        { name: 'check2', status: 'completed', conclusion: 'failed' },
-        { name: 'check3', status: 'pending', conclusion: '' },
-      ]
-    });
-    stub.onSecondCall().callsArgWith(2, null, {
-      check_runs: [
-        { name: 'check1', status: 'completed', conclusion: 'success' },
-        { name: 'check2', status: 'completed', conclusion: 'failed' },
-        { name: 'check3', status: 'completed', conclusion: 'success' },
-      ]
-    });
-
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.not.exists(err);
-      sha.should.be.eql(aSha);
-      done();
-    });
-  });
-
-  it('should fail when one of the require checks failed', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: ['check1', 'check3']
-      },
-      getChecksForRefRes: {
-        check_runs: [
-          { name: 'check1', status: 'completed', conclusion: 'success' },
-          { name: 'check2', status: 'completed', conclusion: 'failed' },
-          { name: 'check3', status: 'completed', conclusion: 'failed' }
-        ]
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.exists(err);
-      err.message.should.be.eql('CHECKS_FAILED');
-      done();
-    });
-  });
-
-  it('should fail when the last execution of one of the require checks failed although previous succeeded', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: ['check1', 'check3']
-      },
-      getChecksForRefRes: {
-        check_runs: [
-          { name: 'check1', status: 'completed', conclusion: 'failed' },
-          { name: 'check2', status: 'completed', conclusion: 'failed' },
-          { name: 'check3', status: 'completed', conclusion: 'success' },
-          { name: 'check1', status: 'completed', conclusion: 'success' }
-        ]
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.exists(err);
-      err.message.should.be.eql('CHECKS_FAILED');
-      done();
-    });
-  });
-
-  it('should succeed when the last execution of all of the require checks succeeded although previous failed', (done) => {
-    const aSha = '123';
-    const githubDummy = createGithubDummy(null, {
-      getBranchRes: {
-        object: {
-          sha: aSha
-        }
-      },
-      getProtectedBranchRequiredStatusChecksRes: {
-        contexts: ['check1', 'check3']
-      },
-      getChecksForRefRes: {
-        check_runs: [
-          { name: 'check1', status: 'completed', conclusion: 'success' },
-          { name: 'check2', status: 'completed', conclusion: 'failed' },
-          { name: 'check3', status: 'completed', conclusion: 'success' },
-          { name: 'check1', status: 'completed', conclusion: 'failed' }
-        ]
-      }
-    });
-    const getBranchStatus = createGetBranchStatus(githubDummy, POLLING_INTERVAL_MS);
-
-    const repo = 'audienseCo';
-    const branch = 'staging';
-    getBranchStatus(repo, branch, (err, sha) => {
-      should.not.exists(err);
-      sha.should.be.eql(aSha);
-      done();
-    });
-  });
 
   function createGithubDummy(err, {
     getBranchRes,
-    getProtectedBranchRequiredStatusChecksRes,
-    getChecksForRefRes,
-    getProtectedBranchRequiredStatusChecksError
   }) {
-    var calls = [];
-    function called(name, cb) {
-      calls.push(name);
-    }
-    function wasCalled(name) {
-      return calls.includes(name)
-    }
     return {
-      getBranch: (repo, branch, cb) => called('getBranch', cb(err, getBranchRes)),
-      getProtectedBranchRequiredStatusChecks: (repo, branch, cb) => called('getProtectedBranchRequiredStatusChecks', cb(getProtectedBranchRequiredStatusChecksError, getProtectedBranchRequiredStatusChecksRes)),
-      getChecksForRef: (repo, ref, cb) => called('getChecksForRefRes', cb(err, getChecksForRefRes)),
-      wasCalled: wasCalled
+      getBranch: (repo, branch, cb) => cb(err, getBranchRes),
     };
   }
 });

--- a/test/core/services/getBranchStatus_spec.js
+++ b/test/core/services/getBranchStatus_spec.js
@@ -154,7 +154,7 @@ describe('get branch status service', () => {
     });
   });
 
-  it('should wait when one of the require checks is not completed', (done) => {
+  it.skip('should wait when one of the require checks is not completed', (done) => {
     const aSha = '123';
     const githubDummy = createGithubDummy(null, {
       getBranchRes: {


### PR DESCRIPTION
Problems related with this feature:

 * Using statusForRef got only some CI checks
 * Using check status got only checks from github actions
 * A healthy branch and a PR healthy are not the same, so we can't use
the checks from branch protection:
    * A PR could have required this checks before merge:
        * CI Tool
        * Monorail Deploy Labels
    * When the Branch would have:
        * CI Tool