### PR TITLE
Rollback command

### DIFF
--- a/core/services/build.js
+++ b/core/services/build.js
@@ -39,9 +39,9 @@ module.exports = (callCIDriver) => {
 
     if (repoCIJobConfig.servicesParam) {
       if (repoCIJobConfig.servicesParam.paramPath) {
-        set(params, repoCIJobConfig.servicesParam.paramPath, job.deployTo.join(repoCIJobConfig.servicesParam.separator));
+        set(params, repoCIJobConfig.servicesParam.paramPath, joinDeployJobs(job.deployTo, repoCIJobConfig.servicesParam.separator));
       }
-      else params[repoCIJobConfig.servicesParam.paramName] = job.deployTo.join(repoCIJobConfig.servicesParam.separator);
+      else params[repoCIJobConfig.servicesParam.paramName] = joinDeployJobs(job.deployTo, repoCIJobConfig.servicesParam.separator);
     }
 
     if (repoCIJobConfig.sourceVersionParam) {
@@ -69,5 +69,11 @@ module.exports = (callCIDriver) => {
     return assignWith(finalObj, originalObj, (defaultProp, originalProp) => {
       return isNil(originalProp) ? defaultProp : originalProp;
     });
+  }
+
+  function joinDeployJobs(deployTo, separator) {
+    return deployTo
+      .map(job => job.name || job)
+      .join(separator);
   }
 }

--- a/core/services/getRepoConfig.js
+++ b/core/services/getRepoConfig.js
@@ -1,5 +1,6 @@
 'use strict';
 const { get } = require('lodash');
+const logger = require('../../lib/logger');
 const CONFIG_FILE_PATH = '.monorail';
 
 module.exports = (github, localConfig) => {
@@ -19,6 +20,7 @@ module.exports = (github, localConfig) => {
       return JSON.parse(content);
     }
     catch(e) {
+      logger.error(`Error parsing ${CONFIG_FILE_PATH} file, invalid JSON.`, e);
       return;
     }
   }

--- a/lib/logger/logger.js
+++ b/lib/logger/logger.js
@@ -3,6 +3,7 @@ module.exports = (settings, createLogger) => {
   const logger = createLogger(settings);
 
   function error() {
+    logger.debug(...arguments);
     logger.error(...arguments);
   };
 

--- a/presentation/github/releaseNotes.js
+++ b/presentation/github/releaseNotes.js
@@ -17,7 +17,7 @@ module.exports = () => {
       const formatedParams = map(job.params, (value, key) => `${key}: ${JSON.stringify(value)}`).join('\n');
       return [
         `### Deploy job: ${job.name}`,
-        `**Services**: ${job.deployTo.join(', ')}`,
+        `**Services**: ${job.deployTo.map(job => job.name || job).join(', ')}`,
         `**Params**:`,
         formatedParams
       ].join('\n');

--- a/presentation/slack/preview-release/release-preview.js
+++ b/presentation/slack/preview-release/release-preview.js
@@ -16,7 +16,7 @@ module.exports = ({ repo, prIds, issues, deployInfo }, filterLabels, user) => {
   }, []).join('\n');
   if (!formatedIssues) return;
 
-  const formatedServices = deployInfo.jobs.map(job => `*${job.name}*: ${job.deployTo.join(', ')}`).join('\n');
+  const formatedServices = deployInfo.jobs.map(job => `*${job.name}*: ${job.deployTo.map(job => job.name || job).join(', ')}`).join('\n');
 
   const text =
   `*Pull Requests*: ${formatedPRs}

--- a/test/core/actions/slackPreviewRelease_spec.js
+++ b/test/core/actions/slackPreviewRelease_spec.js
@@ -81,7 +81,10 @@ describe('slackPreviewRelease action', () => {
     it('should notify the release preview with PRs, issues and deploy info', done => {
       const githubDummy = createGithubDummy();
       const stub = sinon.stub(githubDummy, 'getIssueLabels');
-      stub.onFirstCall().callsArgWith(2, null, [{ name: 'deploy-to:task-as' }]);
+      stub.onFirstCall().callsArgWith(2, null, [
+        { name: 'deploy-to:task-as' },
+        { name: 'deploy-to:rollbackeable-service' }
+      ]);
       stub.onSecondCall().callsArgWith(2, null, [{ name: 'deploy-to:globalreports' }]);
       const notifyStub = createNotifyStub();
       const previewRelease = createPrevieReleaseWithStubs({ github: githubDummy, notify: notifyStub });
@@ -104,7 +107,8 @@ describe('slackPreviewRelease action', () => {
             {
               name: 'nodejs v8.6.0',
               deployTo: [
-                'task-as'
+                'task-as',
+                { "name": "rollbackeable service", "rollback": true }
               ],
               params: {}
             }

--- a/test/core/services/build_spec.js
+++ b/test/core/services/build_spec.js
@@ -20,7 +20,11 @@ describe('Build service', () => {
     const jobs = [
       {
         name: 'nodejs v8.6.0',
-        deployTo: ['task-as', 'globalreports-as'],
+        deployTo: [
+          'task-as',
+          'globalreports-as',
+          { name: "rollbackeable service", rollback: true }
+        ],
         params: {
           grunt: true,
           static_files_version: 'other',
@@ -50,7 +54,7 @@ describe('Build service', () => {
         grunt: true,
         static_files_version: 'other',
         statics: false,
-        where_to_deploy: 'task-as,globalreports-as'
+        where_to_deploy: 'task-as,globalreports-as,rollbackeable service'
       });
       callCIDriverSpy.secondCall.args[0].should.be.eql('jenkins');
       callCIDriverSpy.secondCall.args[1].should.be.eql(deployConfig.ciServices.jenkins_deploy.settings);

--- a/test/core/services/deployInfoFromPullRequests_spec.js
+++ b/test/core/services/deployInfoFromPullRequests_spec.js
@@ -30,7 +30,11 @@ describe('Get pull requests deploy info service', () => {
       const repo = 'socialbro';
 
       stub.onFirstCall().callsArgWith(2, null, [{ name: 'deploy-to:task-as' }]);
-      stub.onSecondCall().callsArgWith(2, null, [{ name: 'deploy-to:globalreports' }, { name: 'deploy-to:dashboard' }]);
+      stub.onSecondCall().callsArgWith(2, null, [
+        { name: 'deploy-to:globalreports' },
+        { name: 'deploy-to:dashboard' },
+        { name: 'deploy-to:rollbackeable-service' }
+      ]);
       const prDeployInfo = createPullRequestDeployInfo(githubDummy);
       const deployInfoFromPullRequests = createDeployInfoFromPullRequests(prDeployInfo);
       deployInfoFromPullRequests(repo, [1234, 4321], repoConfig.deploy, (err, info) => {
@@ -39,12 +43,19 @@ describe('Get pull requests deploy info service', () => {
           jobs: [
             {
               name: 'nodejs v8.6.0',
-              deployTo: ['task-as', 'globalreports-as'],
+              deployTo: [
+                'task-as',
+                'globalreports-as',
+                { "name": "rollbackeable service", "rollback": true }
+              ],
               params: {}
             },
             {
               name: 'nodejs v10.0.0',
-              deployTo: ['dashboard-as', 'task-as'],
+              deployTo: [
+                'dashboard-as',
+                'task-as'
+              ],
               params: {
                 grunt: true,
                 statics: true

--- a/test/core/services/deploy_spec.js
+++ b/test/core/services/deploy_spec.js
@@ -37,7 +37,11 @@ describe('deploy service', () => {
         jobs: [
           {
             name: 'nodejs v8.6.0',
-            deployTo: ['task-as', 'globalreports-as'],
+            deployTo: [
+              'task-as',
+              'globalreports-as',
+              { "name": "rollbackeable service", "rollback": true }
+            ],
             params: {}
           },
           {

--- a/test/core/services/getConfig_spec.js
+++ b/test/core/services/getConfig_spec.js
@@ -274,7 +274,8 @@ describe('getConfig service', () => {
         "globalreports": {
           "ciJob": "nodejs v8.6.0",
           "deployTo": [
-            "globalreports-as"
+            "globalreports-as",
+            { name: "rollbackeable service", rollback: true }
           ]
         }
       };

--- a/test/core/services/getReleasePreview_spec.js
+++ b/test/core/services/getReleasePreview_spec.js
@@ -165,7 +165,10 @@ describe('getReleasePreview service', () => {
       reposInfo[0].deployInfo.jobs.should.be.eql([
         {
           name: 'nodejs v8.6.0',
-          deployTo: ['task-as'],
+          deployTo: [
+            { "name": "rollbackeable service", "rollback": true },
+            'task-as'
+          ],
           params: {}
         }
       ]);
@@ -191,7 +194,10 @@ describe('getReleasePreview service', () => {
         };
         cb(err, res || defaultRes);
       },
-      getIssueLabels: (repo, id, cb) => cb(err, [{ name: 'deploy-to:task-as' }]),
+      getIssueLabels: (repo, id, cb) => cb(err, [
+        { name: 'deploy-to:rollbackeable-service'},
+        { name: 'deploy-to:task-as' }
+      ]),
       getPullRequest: (repo, id, cb) => cb(err, { title: 'Foo PR', body: 'Closes #4321' }),
       getIssue: (repo, id, cb) => {
         cb(err, {

--- a/test/fixtures/repoConfig.json
+++ b/test/fixtures/repoConfig.json
@@ -132,6 +132,14 @@
         ],
         "params": {
         }
+      },
+      "rollbackeable-service": {
+        "ciJob": "nodejs v8.6.0",
+        "deployTo": [
+          { "name": "rollbackeable service", "rollback": true }
+        ],
+        "params": {
+        }
       }
     }
   }

--- a/test/presentation/github/releaseNotes_spec.js
+++ b/test/presentation/github/releaseNotes_spec.js
@@ -25,7 +25,11 @@ describe('Github Release Notes Template', () => {
       deployInfo: {
         jobs: [{
           name: 'nodejs v10',
-          deployTo: ['dashboard', 'tasks'],
+          deployTo: [
+            'dashboard',
+            'tasks',
+            { "name": "rollbackeable service", "rollback": true }
+          ],
           params: {
             grunt: true,
             statics: false
@@ -38,7 +42,7 @@ describe('Github Release Notes Template', () => {
 `## Tag: v2011-10-05T14:48:00.000Z
 
 ### Deploy job: nodejs v10
-**Services**: dashboard, tasks
+**Services**: dashboard, tasks, rollbackeable service
 **Params**:
 grunt: true
 statics: false

--- a/test/presentation/slack/preview-release/preview_spec.js
+++ b/test/presentation/slack/preview-release/preview_spec.js
@@ -98,8 +98,8 @@ describe('Preview Release Slack Notification Template', () => {
       }],
       deployInfo: {
         jobs: [{
-          name: 'nodejs v10',
-          deployTo: ['dashboard', 'tasks']
+          name: 'nodejs v8.6.0',
+          deployTo: ['dashboard', 'tasks', { "name": "rollbackeable service", "rollback": true }]
         }]
       }
     }];
@@ -113,7 +113,7 @@ describe('Preview Release Slack Notification Template', () => {
         text:
 `*Pull Requests*: <https://github.com/AudienseCo/repo1/issues/10|#10>, <https://github.com/AudienseCo/repo1/issues/20|#20>, <https://github.com/AudienseCo/repo1/issues/30|#30>
 
-*nodejs v10*: dashboard, tasks
+*nodejs v8.6.0*: dashboard, tasks, rollbackeable service
 
 *Issues*:\n<https://github.com/AudienseCo/repo1/issues/123|#123> issue title
 

--- a/test/presentation/slack/release/release_spec.js
+++ b/test/presentation/slack/release/release_spec.js
@@ -79,8 +79,8 @@ describe('Release Slack Notification Template', () => {
       }],
       deployInfo: {
         jobs: [{
-          name: 'nodejs v10',
-          deployTo: ['dashboard', 'tasks']
+          name: 'nodejs v8.6.0',
+          deployTo: ['dashboard', 'tasks', { "name": "rollbackeable service", "rollback": true }]
         }]
       }
     }];
@@ -94,6 +94,7 @@ describe('Release Slack Notification Template', () => {
 
 <https://github.com/AudienseCo/repo1/issues/123|#123> issue title <@slack_username1>, <@username2>, <@slack_username3>
 
+Rollback: \`!monorail rollback on rollbackeable service\`
 `,
         color: 'good',
         title: 'repo1',


### PR DESCRIPTION
This PR adds support for optional rollback command hints.
For a service's job to be added to the rollback hint add `rollback: true` to its setting in the `.monorail` config file:

```
  "deploy": {
    "services": {
      "service name": {
        "ciJob": "ruby vX",
        "deployTo": [
          { "name": "job-name", "rollback": true },
          "another-non-rollbackeable-job"
        ],
        "params": {
        }
      },
...
```

![Captura de pantalla 2020-10-06 a las 17 31 16](https://user-images.githubusercontent.com/92608/95223539-01e5fc00-07fa-11eb-946b-03023050f015.png)
