### PR TITLE
chore(checkers): decommission deploy-labels checker

### DIFF
--- a/core/actions/index.js
+++ b/core/actions/index.js
@@ -4,8 +4,17 @@ const config = require('../../config');
 const pollingIntervalMS = config.github.pollingIntervalMS || 30000;
 
 const checkers = [
-  require('../services/checkers/deploy-notes'),
-  require('../services/checkers/deploy-labels')
+  require('../services/checkers/deploy-notes')
+  // 'deploy-labels' checker decommissioned: the "Deploy Labels" commit status
+  // is now posted by a native GitHub Action in socialbro
+  // (.github/workflows/deploy-labels.yml). This webhook path was unstable — the
+  // AWS ALB in front of monorail intermittently rejected label webhooks with
+  // 403 and GitHub does not retry 4xx deliveries, so toggling labels often
+  // failed to re-evaluate the check. Disabling the subscriber here stops
+  // monorail from posting (and competing for) that status. The deploy pipeline
+  // reads deploy-to:* labels directly (pullRequestDeployInfo / deploy), so this
+  // does not affect deployments.
+  // require('../services/checkers/deploy-labels')
 ];
 
 const deploysController = require('../services/deploysController')();


### PR DESCRIPTION
## Why

The `Deploy Labels` commit status that this checker posts has been **reimplemented as a native GitHub Action** in socialbro (`.github/workflows/deploy-labels.yml`, context `Monorail Labels` during validation, to become `Deploy Labels` at cutover).

The monorail webhook path is structurally unstable. From the socialbro webhook delivery log (hook `8018417`):

```
pull_request.unlabeled  403   ← rejected by ALB (Server: awselb/2.0)
pull_request.labeled    403
pull_request.labeled    403
pull_request.unlabeled  403
pull_request.labeled    200 OK ← recovered minutes later
```

The **AWS ALB in front of monorail returns intermittent 403s** before the request reaches the app (valid HMAC, so not auth). GitHub **does not retry 4xx webhook deliveries**, so toggling labels frequently fails to re-evaluate the check and the required status is never posted — blocking PRs with no red X and no re-run button. The native Action removes the ALB/lost-webhook chain and adds a Re-run button; verified live to flip success/failure on label add/remove within seconds.

## Change

Unsubscribe the `deploy-labels` checker by removing it from the `checkers` array in `core/actions/index.js` (same pattern as the prior `qa-review` checker removal, #98). The checker files are left in place; only the subscription is removed.

## Safety

- **Deployments are unaffected.** The deploy pipeline reads `deploy-to:*` labels directly (`pullRequestDeployInfo`, `deployInfoFromPullRequests`, `deploy`), not via this checker. The checker only posted a commit status.
- The sibling `deploy-notes` checker is left untouched.
- `node --check core/actions/index.js` passes. (Full suite not run locally — this checkout has no `node_modules` and pins Node 8/10; CI will run it.)

## Coordinate before merge

Merging this stops monorail posting `Deploy Labels`. Make sure the socialbro side has cut over first (the Action made required as `Deploy Labels`, and the old `Deploy Labels` context handled in branch protection), otherwise PRs could lose the required status entirely.